### PR TITLE
Added scala file extension

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -17,7 +17,7 @@ var SPECIFICATION_VERSION = '0.2.0';
 
 var defaults = {
     excludeFilters: [],
-    includeFilters: [ '.*\\.(clj|coffee|cs|dart|erl|go|java|js|php?|py|rb|ts|pm)$' ],
+    includeFilters: [ '.*\\.(clj|coffee|cs|dart|erl|go|java|scala|js|php?|py|rb|ts|pm)$' ],
 
     src: path.join(__dirname, '../example/'),
 


### PR DESCRIPTION
Since [Scala](http://docs.scala-lang.org/style/scaladoc.html) follows Javadoc conventions, we can safely add the `.scala` file extension to `includeFilters` defaults.