### PR TITLE
Parameter name array syntax

### DIFF
--- a/lib/parsers/api_param.js
+++ b/lib/parsers/api_param.js
@@ -36,7 +36,7 @@ var regExp = {
     },
     wName: {
         b:               '(\\[?\\s*',                       // 5 optional optional-marker
-        name:                '([a-zA-Z0-9\\.\\/\\\\_-]+)', // 6
+        name:                '([a-zA-Z0-9\\.\\/\\\\_-]+(?:\\[\\])?)', // 6
         oDefaultValue: {                                    // optional defaultValue
             b:               '(?:\\s*=\\s*(?:',             // starting with '=', optional surrounding spaces
             withDoubleQuote:     '"([^"]*)"',               // 7

--- a/lib/parsers/api_param.js
+++ b/lib/parsers/api_param.js
@@ -36,7 +36,7 @@ var regExp = {
     },
     wName: {
         b:               '(\\[?\\s*',                       // 5 optional optional-marker
-        name:                '([a-zA-Z0-9\\.\\/\\\\_-]+(?:\\[\\])?)', // 6
+        name:                '([a-zA-Z0-9\\.\\/\\\\_-]+(?:\\[[a-zA-Z0-9\\.\\/\\\\_-]*\\])?)', // 6
         oDefaultValue: {                                    // optional defaultValue
             b:               '(?:\\s*=\\s*(?:',             // starting with '=', optional surrounding spaces
             withDoubleQuote:     '"([^"]*)"',               // 7


### PR DESCRIPTION
Hi,

I've started using apidocjs but noticed that it doesn't currently handle parameter names with [ ] brace characters in them.
Do you think it makes sense to support these kinds of parameter names in apidoc?

For example:
```
@apiParam {String} item[]
@apiParam {String} thing[name]
@apiParam {String} [something_optional[]]
```
