### PR TITLE
Fix sample request issue. Remove 'type' in markdown fields.

### DIFF
--- a/lib/parsers/api_param.js
+++ b/lib/parsers/api_param.js
@@ -132,5 +132,5 @@ module.exports = {
     path          : path,
     method        : 'push',
     getGroup      : getGroup,
-    markdownFields: [ 'description', 'type' ]
+    markdownFields: [ 'description' ]
 };


### PR DESCRIPTION
![apidoc-issue](https://cloud.githubusercontent.com/assets/4861856/8153857/32ad96c4-1366-11e5-843c-434a2d1b1957.png)
Type field via markdown render to 'Sample Request' cause display issue.