### PR TITLE
Removed 'type' from the markdownFields array

### DIFF
--- a/lib/parsers/api_error.js
+++ b/lib/parsers/api_error.js
@@ -16,5 +16,5 @@ module.exports = {
     parse         : parse,
     path          : path,
     method        : apiParser.method,
-    markdownFields: [ 'description', 'type' ]
+    markdownFields: [ 'description' ]
 };

--- a/lib/parsers/api_param.js
+++ b/lib/parsers/api_param.js
@@ -132,5 +132,5 @@ module.exports = {
     path          : path,
     method        : 'push',
     getGroup      : getGroup,
-    markdownFields: [ 'description', 'type' ]
+    markdownFields: [ 'description' ]
 };

--- a/lib/parsers/api_success.js
+++ b/lib/parsers/api_success.js
@@ -16,5 +16,5 @@ module.exports = {
     parse         : parse,
     path          : path,
     method        : apiParser.method,
-    markdownFields: [ 'description', 'type' ]
+    markdownFields: [ 'description' ]
 };


### PR DESCRIPTION
Sample request parameter types are shown with paragraph tags #300.  In addition to fixing the parameter parser this also updates error and success too.