### PR TITLE
feature: condition filter by author and tags.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -55,6 +55,8 @@ var app = {
     parsers: {
         api                      : './parsers/api.js',
         apidefine                : './parsers/api_define.js',
+        apiauthor                : './parsers/api_author.js',
+        apitags                  : './parsers/api_tags.js',
         apidescription           : './parsers/api_description.js',
         apierror                 : './parsers/api_error.js',
         apierrorexample          : './parsers/api_error_example.js',
@@ -75,6 +77,8 @@ var app = {
     workers: {
         apierrorstructure        : './workers/api_error_structure.js',
         apierrortitle            : './workers/api_error_title.js',
+        apiauthor                : './workers/api_author.js',
+        apitags                  : './workers/api_tags.js',
         apigroup                 : './workers/api_group.js',
         apiheaderstructure       : './workers/api_header_structure.js',
         apiheadertitle           : './workers/api_header_title.js',

--- a/lib/parsers/api_author.js
+++ b/lib/parsers/api_author.js
@@ -1,0 +1,22 @@
+// Same as @apiParam
+var trim = require('../utils/trim');
+
+function parse(content) {
+    var author = trim(content);
+
+    if(author.length === 0)
+        return null;
+
+    return {
+        author: author.split(/[\s,]+/)
+    };
+}
+
+/**
+ * Exports
+ */
+module.exports = {
+    parse         : parse,
+    path          : 'local',
+    method        : 'insert'
+};

--- a/lib/parsers/api_tags.js
+++ b/lib/parsers/api_tags.js
@@ -1,0 +1,22 @@
+// Same as @apiParam
+var trim = require('../utils/trim');
+
+function parse(content) {
+    var tags = trim(content);
+
+    if(tags.length === 0)
+        return null;
+
+    return {
+        tags: tags.split(/[\s,]+/)
+    };
+}
+
+/**
+ * Exports
+ */
+module.exports = {
+    parse         : parse,
+    path          : 'local',
+    method        : 'insert'
+};

--- a/lib/workers/api_author.js
+++ b/lib/workers/api_author.js
@@ -1,0 +1,35 @@
+/**
+ * PostProcess
+ *
+ * Priority: process after use and api
+ *
+ * @param {Object[]} parsedFiles
+ * @param {String[]} filenames
+ * @param {Object[]} preProcess
+ * @param {Object}   packageInfos
+ */
+function postProcess(parsedFiles/*, filenames, preProcess, packageInfos*/) {
+    var target = 'author';
+
+    parsedFiles.forEach(function(parsedFile) {
+        parsedFile.forEach(function(block) {
+            // Ignore global name, or non existing global names (that will be generated with this func)
+            // could overwrite local names on a later starting worker process from e.g. @apiUse
+            if (Object.keys(block.global).length === 0) {
+                var author = block.local[target];
+                if ( ! author) {
+                    author = [];
+                }
+
+                block.local[target] = author;
+            }
+        });
+    });
+}
+
+/**
+ * Exports
+ */
+module.exports = {
+    postProcess: postProcess
+};

--- a/lib/workers/api_tags.js
+++ b/lib/workers/api_tags.js
@@ -1,0 +1,35 @@
+/**
+ * PostProcess
+ *
+ * Priority: process after use and api
+ *
+ * @param {Object[]} parsedFiles
+ * @param {String[]} filenames
+ * @param {Object[]} preProcess
+ * @param {Object}   packageInfos
+ */
+function postProcess(parsedFiles/*, filenames, preProcess, packageInfos*/) {
+    var target = 'tags';
+
+    parsedFiles.forEach(function(parsedFile) {
+        parsedFile.forEach(function(block) {
+            // Ignore global name, or non existing global names (that will be generated with this func)
+            // could overwrite local names on a later starting worker process from e.g. @apiUse
+            if (Object.keys(block.global).length === 0) {
+                var tags = block.local[target];
+                if ( ! tags) {
+                    tags = [];
+                }
+
+                block.local[target] = tags;
+            }
+        });
+    });
+}
+
+/**
+ * Exports
+ */
+module.exports = {
+    postProcess: postProcess
+};


### PR DESCRIPTION
# condition filter by author and tags.

Hello,

In this commit, Here is two fields `tags` and `author`, and click to filter by author or tags. 

In a project, we can filter by author to review someone's api, and add some tags such as product requirements document version、todos list and filter by these tags.

Example:

![apidoc_tags_author](https://cloud.githubusercontent.com/assets/9150374/9138989/e22f3040-3d59-11e5-9a12-bab746d28d06.png)

Regards,
Yufei Li
