### PR TITLE
The Hangul(Korean characters) allow in the group-name field.

### DIFF
--- a/lib/workers/api_group.js
+++ b/lib/workers/api_group.js
@@ -80,7 +80,7 @@ function postProcess(parsedFiles, filenames, preProcess, packageInfos, source, t
                 }
 
                 // replace special chars
-                group = group.replace(/[^\w]/g, '_');
+                group = group.replace(/[^\w\u3130-\u318F\uAC00-\uD7AF]/g, '_');
 
                 block.local[target] = group;
             }


### PR DESCRIPTION
Greetings,

I've just started using apidocjs for my API project and it's awesome open source ! 

I tried to write Korean characters in the group name field like "@apiGroup 결제". 

you know, I'm a Korean(south) but I have a problem using Korean characters. 

even if I use the Korean language and confirmed that there is no problem. 

Please check this commiting for the Korea people. thanks.
