### PR TITLE
Read @apiSuccessExample from file

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -187,6 +187,7 @@ Parser.prototype._parseBlockElements = function(indexApiBlocks, detectedElements
                 var pathTo;
                 var attachMethod;
                 try {
+                    global.currentFile=filename;
                     // parse element and retrieve values
                     values = elementParser.parse(element.content, element.source);
 

--- a/lib/parsers/api_example.js
+++ b/lib/parsers/api_example.js
@@ -1,31 +1,34 @@
 var trim = require('../utils/trim');
 var unindent = require('../utils/unindent');
 var fs = require('fs');
+var path = require('path');
+
 
 function parse(content, source) {
     source = trim(source);
 
     var title = '';
     var text = '';
-    var extFile = null;
     var type;
 
     // Search for @apiExample "[{type}] title and content
     // /^(@\w*)?\s?(?:(?:\{(.+?)\})\s*)?(.*)$/gm;
     var parseRegExpFirstLine = /(@\w*)?(?:(?:\s*\{\s*([a-zA-Z0-9\.\/\\\[\]_-]+)\s*\}\s*)?\s*(.*)?)?/;
     var parseRegExpFollowing = /(^.*\s?)/gm;
+    var cutFilePathRegExp = /\{[\s]?path.*\}/g;
 
     var matches;
     if ((matches = parseRegExpFirstLine.exec(source))) {
         type = matches[2];
         title = matches[3];
-        if (title.replace(' ', '').includes('{path=')) {
-            extFile = title.replace(' ', '').split('{path=')[1].split('}')[0];
+        if (title.replace(' ', '').indexOf('{path=') > -1) {
+            var extFile = title.replace(' ', '').split('{path=')[1].split('}')[0];
+            var currentDir = path.dirname(global.currentFile) + path.sep;
+            text += fs.readFileSync(currentDir + extFile);
+            text += '\n';
+            title = title.replace(cutFilePathRegExp, '');
         }
     }
-
-    text += fs.readFileSync(extFile);
-    text += '\n';
 
     parseRegExpFollowing.exec(content); // ignore line 1
     while ((matches = parseRegExpFollowing.exec(source))) {

--- a/lib/parsers/api_example.js
+++ b/lib/parsers/api_example.js
@@ -15,7 +15,7 @@ function parse(content, source) {
     // /^(@\w*)?\s?(?:(?:\{(.+?)\})\s*)?(.*)$/gm;
     var parseRegExpFirstLine = /(@\w*)?(?:(?:\s*\{\s*([a-zA-Z0-9\.\/\\\[\]_-]+)\s*\}\s*)?\s*(.*)?)?/;
     var parseRegExpFollowing = /(^.*\s?)/gm;
-    var cutFilePathRegExp = /\{[\s]?path.*\}/g;
+    var cutFilePathRegExp = /\{[\s]?path[\s]?=[\s]?(.*?)[\s]?\}/g;
 
     var matches;
     if ((matches = parseRegExpFirstLine.exec(source))) {

--- a/lib/parsers/api_example.js
+++ b/lib/parsers/api_example.js
@@ -1,11 +1,13 @@
-var trim     = require('../utils/trim');
+var trim = require('../utils/trim');
 var unindent = require('../utils/unindent');
+var fs = require('fs');
 
 function parse(content, source) {
     source = trim(source);
 
     var title = '';
     var text = '';
+    var extFile = null;
     var type;
 
     // Search for @apiExample "[{type}] title and content
@@ -14,13 +16,19 @@ function parse(content, source) {
     var parseRegExpFollowing = /(^.*\s?)/gm;
 
     var matches;
-    if ( (matches = parseRegExpFirstLine.exec(source)) ) {
+    if ((matches = parseRegExpFirstLine.exec(source))) {
         type = matches[2];
         title = matches[3];
+        if (title.replace(' ', '').includes('{path=')) {
+            extFile = title.replace(' ', '').split('{path=')[1].split('}')[0];
+        }
     }
 
+    text += fs.readFileSync(extFile);
+    text += '\n';
+
     parseRegExpFollowing.exec(content); // ignore line 1
-    while ( (matches = parseRegExpFollowing.exec(source)) )  {
+    while ((matches = parseRegExpFollowing.exec(source))) {
         text += matches[1];
     }
 
@@ -28,9 +36,9 @@ function parse(content, source) {
         return null;
 
     return {
-        title  : title,
+        title: title,
         content: unindent(text),
-        type   : type || 'json'
+        type: type || 'json'
     };
 }
 
@@ -38,7 +46,7 @@ function parse(content, source) {
  * Exports
  */
 module.exports = {
-    parse : parse,
-    path  : 'local.examples',
+    parse: parse,
+    path: 'local.examples',
     method: 'push'
 };


### PR DESCRIPTION
Followed by https://github.com/apidoc/apidoc/issues/182

It is now able to use file content in examples. 

```
/**
* @apiParamExample {json} Request-Example: {path=json/optional-request.json}
* @apiSuccessExample {json} Response-Example: {path=json/optional-response.json}
* {"msg":"another json optional"}
*/
```

In this case it will need to only parse the first line witth affected annotation, search {path=.*} (relative to current file/)
and if it found make request, add data to example and then add inner json if exists.
So it will backwards capable and and these two options will comply each other.

I`m not familliar with nodejs so code is little nasty. But it is good as start of implementation.
