### PR TITLE
Added Elixir support

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -18,7 +18,7 @@ var SPECIFICATION_VERSION = '0.2.0';
 
 var defaults = {
     excludeFilters: [],
-    includeFilters: [ '.*\\.(clj|coffee|cs|dart|erl|go|java|js|litcoffee|php?|py|rb|scala|ts|pm)$' ],
+    includeFilters: [ '.*\\.(clj|coffee|cs|dart|erl|exs?|go|java|js|litcoffee|php?|py|rb|scala|ts|pm)$' ],
 
     src: path.join(__dirname, '../example/'),
 
@@ -46,6 +46,7 @@ var app = {
         '.clj'                   : './languages/clj.js',
         '.coffee'                : './languages/coffee.js',
         '.erl'                   : './languages/erl.js',
+        '.ex'                    : './languages/ex.js',
         '.litcoffee'             : './languages/coffee.js',
         '.pm'                    : './languages/pm.js',
         '.py'                    : './languages/py.js',

--- a/lib/languages/ex.js
+++ b/lib/languages/ex.js
@@ -1,0 +1,11 @@
+/**
+ * Elixir
+ */
+module.exports = {
+    // Find document blocks in heredocs that are arguments of the @apidoc
+    // module attribute. Elixir heredocs can be enclosed between """ and """ or
+    // between ''' and '''. Heredocs in ~s and ~S sigils are also supported.
+    docBlocksRegExp: /@apidoc\s*(~[sS])?("""\uffff?(.+?)\uffff?(?:\s*)?"""|'''\uffff?(.+?)\uffff?(?:\s*)?''')/g,
+    // Remove not needed tabs at the beginning
+    inlineRegExp: /^(\t*)?/gm
+};


### PR DESCRIPTION
This pull request adds support for the Elixir language. It differs from pull request #9 in that it supports all available heredoc variants. Instead of using the `@doc` module attribute which is reserved for [ExDoc](https://github.com/elixir-lang/ex_doc "ExDoc") a custom `@apidoc` module attribute is used.

Example:

        @apidoc """
        @api {get} /user/:id Request User information
        @apiName GetUser
        @apiGroup User

        @apiParam {Number} id Users unique ID.

        @apiSuccess {String} firstname Firstname of the User.
        @apiSuccess {String} lastname  Lastname of the User.
        """

