### PR TITLE
Fix Elixir regexp

### DIFF
--- a/lib/languages/ex.js
+++ b/lib/languages/ex.js
@@ -5,7 +5,7 @@ module.exports = {
     // Find document blocks in heredocs that are arguments of the @apidoc
     // module attribute. Elixir heredocs can be enclosed between """ and """ or
     // between ''' and '''. Heredocs in ~s and ~S sigils are also supported.
-    docBlocksRegExp: /@apidoc\s*(~[sS])?("""\uffff?(.+?)\uffff?(?:\s*)?"""|'''\uffff?(.+?)\uffff?(?:\s*)?''')/g,
+    docBlocksRegExp: /@apidoc\s*(~[sS])?"""\uffff?(.+?)\uffff?(?:\s*)?"""|@apidoc\s*(~[sS])?'''\uffff?(.+?)\uffff?(?:\s*)?'''/g,
     // Remove not needed tabs at the beginning
     inlineRegExp: /^(\t*)?/gm
 };


### PR DESCRIPTION
Unfortunately the group name is not parsed correctly in `@apiUse` annotations for Elixir if `@apiUse` is the last annotation in a comment block. Removing the nested capturing groups from the regexp fixes the issue.