### PR TITLE
allow parser to inject hooks

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -2,6 +2,7 @@ var _    = require('lodash');
 var fs   = require('fs');
 var path = require('path');
 var util = require('util');
+var glob = require('glob');
 
 var findFiles = require('./utils/find_files');
 
@@ -19,6 +20,7 @@ function Parser(_app) {
     // class variables
     self.languages = {};
     self.parsers = {};
+    self.hooks = {};
     self.parsedFileElements = [];
     self.parsedFiles = [];
     self.countDeprecated = {};
@@ -37,6 +39,16 @@ function Parser(_app) {
         var filename = app.parsers[parser];
         app.log.debug('load parser: ' + parser + ', ' + filename);
         self.addParser(parser, require(filename));
+    });
+
+    // load hooks
+    var hooks = glob.sync('../apidoc-plugin-*'); // get list of files
+    console.log(hooks);
+    hooks.forEach(function(hook) {
+	    id = 'api' + hook.substr(17);
+	    console.log(id);
+        app.log.debug('load hook: ' + id + ', ' +hook + ', ');
+        self.addHook(id, require(hook.substr(3)));
     });
 }
 
@@ -62,6 +74,13 @@ Parser.prototype.addLanguage = function(name, language) {
  */
 Parser.prototype.addParser = function(name, parser) {
     this.parsers[name] = parser;
+};
+
+/**
+ * Add a Hook
+ */
+Parser.prototype.addHook = function(name, hook) {
+    this.hooks[name] = hook;
 };
 
 /**
@@ -119,7 +138,7 @@ Parser.prototype.parseFile = function(filename) {
 
     // determine elements in blocks
     self.elements = self.blocks.map(function(block, i) {
-        var elements = self._findElements(block);
+        var elements = self._findElements(block, filename);
         app.log.debug('count elements in block ' + i + ': ' + elements.length);
         return elements;
     });
@@ -412,7 +431,8 @@ Parser.prototype._findBlockWithApiGetIndex = function(blocks) {
 /**
  * Get Elements of Blocks
  */
-Parser.prototype._findElements = function(block) {
+Parser.prototype._findElements = function(block, filename) {
+    var self = this;
     var elements = [];
 
     // Replace Linebreak with Unicode
@@ -432,9 +452,14 @@ Parser.prototype._findElements = function(block) {
         // reverse Unicode Linebreaks
         element.content = element.content.replace(/\uffff/g, '\n');
         element.source = element.source.replace(/\uffff/g, '\n');
-
-        elements.push(element);
-
+		
+		if (self.hooks[element.name]) {
+			var blockExtend = self.hooks[element.name](element, filename);
+            elements = elements.concat(self._findElements(blockExtend, filename));
+        } else {
+			elements.push(element);
+		}
+		
         // next Match
         matches = elementsRegExp.exec(block);
     }

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -42,13 +42,7 @@ function Parser(_app) {
     });
 
     // load hooks
-    var hooks = glob.sync('../apidoc-plugin-*'); // get list of files
-    console.log(hooks);
-    hooks.forEach(function(hook) {
-	    var id = 'api' + hook.substr(17);
-        app.log.debug('load hook: ' + id + ', ' +hook + ', ');
-        self.addHook(id, require(hook.substr(3)));
-    });
+    self.addHooks(__dirname);
 }
 
 /**
@@ -74,6 +68,20 @@ Parser.prototype.addLanguage = function(name, language) {
 Parser.prototype.addParser = function(name, parser) {
     this.parsers[name] = parser;
 };
+
+Parser.prototype.addHooks = function (dir) {
+	var self = this;
+	var list = fs.readdirSync(dir);
+	if (fs.readdirSync(dir).indexOf('node_modules') === -1 ) { return this.addHooks( path.join(dir,'..') )}
+	
+	var hooks = glob.sync(dir+'/node_modules/apidoc-plugin-*');
+    var offset = dir.length + '/node_modules/apidoc-plugin-'.length;
+    hooks.forEach(function(hook) {
+	    var id = 'api' + hook.substr(offset); // 'apidoc-plugin-'.length = 12
+        app.log.debug('load hook: ' + id + ', ' +path.relative(__dirname, hook) + ', ');
+        self.addHook(id, require(hook));
+    });
+}
 
 /**
  * Add a Hook

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -45,8 +45,7 @@ function Parser(_app) {
     var hooks = glob.sync('../apidoc-plugin-*'); // get list of files
     console.log(hooks);
     hooks.forEach(function(hook) {
-	    id = 'api' + hook.substr(17);
-	    console.log(id);
+	    var id = 'api' + hook.substr(17);
         app.log.debug('load hook: ' + id + ', ' +hook + ', ');
         self.addHook(id, require(hook.substr(3)));
     });

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -71,8 +71,7 @@ Parser.prototype.addParser = function(name, parser) {
 
 Parser.prototype.addHooks = function (dir) {
 	var self = this;
-	var list = fs.readdirSync(dir);
-	if (fs.readdirSync(dir).indexOf('node_modules') === -1 ) { return this.addHooks( path.join(dir,'..') )}
+	if (fs.readdirSync(dir).indexOf('node_modules') === -1 ) { return this.addHooks( path.join(dir,'..') ); }
 	
 	var hooks = glob.sync(dir+'/node_modules/apidoc-plugin-*');
     var offset = dir.length + '/node_modules/apidoc-plugin-'.length;
@@ -81,7 +80,7 @@ Parser.prototype.addHooks = function (dir) {
         app.log.debug('load hook: ' + id + ', ' +path.relative(__dirname, hook) + ', ');
         self.addHook(id, require(hook));
     });
-}
+};
 
 /**
  * Add a Hook

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "node": ">= 0.10.0"
   },
   "dependencies": {
+    "glob": "~7.0.3",
     "lodash": "~4.5.0",
     "semver": "~5.1.0",
     "wrench": "~1.5.8"


### PR DESCRIPTION
#26 
Naming convention:

npm package.json
```javascript
"apidoc-plugin-schema":"0.0.1"
```

converted to `apischema` that will lookup `apiSchema` from the docs
