### PR TITLE
Add support for special char in string, such as \" \\ \/ \b…

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -246,7 +246,7 @@ function parse(options) {
             // api_data
             var apiData = JSON.stringify(blocks, null, 2);
             apiData = apiData.replace(/(\r\n|\n|\r)/g, app.options.lineEnding)
-                        .replace(/(\\b)/g, " ")
+                        .replace(/(apidoc_backspace)/g, ' ')
                         .replace(/(apidoc_double_duote)/g, '\\\"')
                         .replace(/(apidoc_reverse_solidus)/g, '\\\\')
                         .replace(/(apidoc_solidus)/g, '\\\/')

--- a/lib/index.js
+++ b/lib/index.js
@@ -245,7 +245,15 @@ function parse(options) {
 
             // api_data
             var apiData = JSON.stringify(blocks, null, 2);
-            apiData = apiData.replace(/(\r\n|\n|\r)/g, app.options.lineEnding);
+            apiData = apiData.replace(/(\r\n|\n|\r)/g, app.options.lineEnding)
+                        .replace(/(\\b)/g, " ")
+                        .replace(/(apidoc_double_duote)/g, '\\\"')
+                        .replace(/(apidoc_reverse_solidus)/g, '\\\\')
+                        .replace(/(apidoc_solidus)/g, '\\\/')
+                        .replace(/(apidoc_formfeed)/g, '\\f')
+                        .replace(/(apidoc_newline)/g, '\\n')
+                        .replace(/(apidoc_carrige_return)/g, '\\r')
+                        .replace(/(apidoc_horizontal_tab)/g, '\\t');
 
             // api_project
             var apiProject = JSON.stringify(app.packageInfos, null, 2);

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -124,6 +124,7 @@ Parser.prototype.parseFile = function(filename, encoding) {
 
     // unify line-breaks
     self.src = self.src.replace(/\r\n/g, '\n');
+    self.src = self.src.replace(/\\b/g, 'apidoc_backspace');
     self.src = self.src.replace(/\\\"/g, 'apidoc_double_duote');
     self.src = self.src.replace(/\\\\/g, 'apidoc_reverse_solidus');
     self.src = self.src.replace(/\\\//g, 'apidoc_solidus');

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -123,14 +123,14 @@ Parser.prototype.parseFile = function(filename, encoding) {
     app.log.debug('size: ' + self.src.length);
 
     // unify line-breaks
-    self.src = self.src.replace(/\r\n/g, '\n')
-                .replace(/\\\"/g, 'apidoc_double_duote') 
-                .replace(/\\\\/g, 'apidoc_reverse_solidus')
-                .replace(/\\\//g, 'apidoc_solidus')
-                .replace(/\\f/g, 'apidoc_formfeed')
-                .replace(/\\n/g, 'apidoc_newline')
-                .replace(/\\r/g, 'apidoc_carrige_return')
-                replace(/\\t/g, 'apidoc_horizontal_tab');
+    self.src = self.src.replace(/\r\n/g, '\n');
+    self.src = self.src.replace(/\\\"/g, 'apidoc_double_duote');
+    self.src = self.src.replace(/\\\\/g, 'apidoc_reverse_solidus');
+    self.src = self.src.replace(/\\\//g, 'apidoc_solidus');
+    self.src = self.src.replace(/\\f/g, 'apidoc_formfeed');
+    self.src = self.src.replace(/\\n/g, 'apidoc_newline');
+    self.src = self.src.replace(/\\r/g, 'apidoc_carrige_return');
+    self.src = self.src.replace(/\\t/g, 'apidoc_horizontal_tab');
 
     self.blocks = [];
     self.indexApiBlocks = [];

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -123,7 +123,14 @@ Parser.prototype.parseFile = function(filename, encoding) {
     app.log.debug('size: ' + self.src.length);
 
     // unify line-breaks
-    self.src = self.src.replace(/\r\n/g, '\n');
+    self.src = self.src.replace(/\r\n/g, '\n')
+                .replace(/\\\"/g, 'apidoc_double_duote') 
+                .replace(/\\\\/g, 'apidoc_reverse_solidus')
+                .replace(/\\\//g, 'apidoc_solidus')
+                .replace(/\\f/g, 'apidoc_formfeed')
+                .replace(/\\n/g, 'apidoc_newline')
+                .replace(/\\r/g, 'apidoc_carrige_return')
+                replace(/\\t/g, 'apidoc_horizontal_tab');
 
     self.blocks = [];
     self.indexApiBlocks = [];


### PR DESCRIPTION
 Add support for special char in string, such as \" \ \/ \b \f \t
When there are some backspaces in json string, parser will split them and let the 1th one to be key-name, others to be description.
In this change, I'd like support the "\b" as same as json.org defined.
Moreover,  support other special chars.
