### PR TITLE
apiConsumes and apiProduces annotations added

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -76,7 +76,9 @@ var app = {
         apisuccessexample        : './parsers/api_success_example.js',
         apiuse                   : './parsers/api_use.js',
         apiversion               : './parsers/api_version.js',
-        apisamplerequest         : './parsers/api_sample_request.js'
+        apisamplerequest         : './parsers/api_sample_request.js',
+        apiconsumes              : './parsers/api_consumes.js',
+        apiproduces              : './parsers/api_produces.js'
     },
     workers: {
         apierrorstructure        : './workers/api_error_structure.js',

--- a/lib/parsers/api_consumes.js
+++ b/lib/parsers/api_consumes.js
@@ -1,0 +1,21 @@
+var trim     = require('../utils/trim');
+var unindent = require('../utils/unindent');
+
+function parse(content) {
+    var consumesType = trim(content);
+
+    if (consumesType.length === 0)
+        return null;
+
+    return unindent(consumesType);
+}
+
+/**
+ * Exports
+ */
+module.exports = {
+    parse         : parse,
+    path          : 'local.consumes',
+    method        : 'push',
+    markdownFields: [ 'consumes' ]
+};

--- a/lib/parsers/api_produces.js
+++ b/lib/parsers/api_produces.js
@@ -1,0 +1,21 @@
+var trim     = require('../utils/trim');
+var unindent = require('../utils/unindent');
+
+function parse(content) {
+    var producesType = trim(content);
+
+    if (producesType.length === 0)
+        return null;
+
+    return unindent(producesType);
+}
+
+/**
+ * Exports
+ */
+module.exports = {
+    parse         : parse,
+    path          : 'local.produces',
+    method        : 'push',
+    markdownFields: [ 'produces' ]
+};


### PR DESCRIPTION
I added two new annotations to set the types that an api endpoint consumes and produces.
I hope you'll find them useful.

Cheers
