### PR TITLE
Allow $ in parameter names

### DIFF
--- a/lib/parsers/api_param.js
+++ b/lib/parsers/api_param.js
@@ -36,7 +36,7 @@ var regExp = {
     },
     wName: {
         b:               '(\\[?\\s*',                       // 5 optional optional-marker
-        name:                '([a-zA-Z0-9\\:\\.\\/\\\\_-]+',   // 6
+        name:                '([a-zA-Z0-9\\$\\:\\.\\/\\\\_-]+',   // 6
             withArray:           '(?:\\[[a-zA-Z0-9\\.\\/\\\\_-]*\\])?)', // https://github.com/apidoc/apidoc-core/pull/4
         oDefaultValue: {                                    // optional defaultValue
             b:               '(?:\\s*=\\s*(?:',             // starting with '=', optional surrounding spaces

--- a/test/parser_api_param_test.js
+++ b/test/parser_api_param_test.js
@@ -43,6 +43,20 @@ describe('Parser: apiParam', function() {
             }
         },
         {
+            title: '$Simple fieldname only',
+            content: '$simple',
+            expected: {
+                group: 'Parameter',
+                type: undefined,
+                size: undefined,
+                allowedValues: undefined,
+                optional: false,
+                field: '$simple',
+                defaultValue: undefined,
+                description: ''
+            }
+        },
+        {
             title: 'All options, with optional defaultValue',
             content: ' ( MyGroup ) { \\Object\\String.uni-code_char[] { 1..10 } = \'abc\', \'def\' }  ' +
                      '[ \\MyClass\\field.user_first-name = \'John Doe\' ] Some description.',


### PR DESCRIPTION
Allow $ in parameter names to document feather.js $limit, $sort parameters
