### PR TITLE
Override allowed and default values from apidoc conf

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -206,7 +206,7 @@ Parser.prototype._parseBlockElements = function(indexApiBlocks, detectedElements
                 var attachMethod;
                 try {
                     // parse element and retrieve values
-                    values = elementParser.parse(element.content, element.source);
+                    values = elementParser.parse(element.content, element.source, app.packageInfos);
 
                     // HINT: pathTo MUST be read after elementParser.parse, because of dynamic paths
                     // Add all other options after parse too, in case of a custom plugin need to modify params.

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -206,7 +206,7 @@ Parser.prototype._parseBlockElements = function(indexApiBlocks, detectedElements
                 var attachMethod;
                 try {
                     // parse element and retrieve values
-                    values = elementParser.parse(element.content, element.source, app.packageInfos);
+                    values = elementParser.parse(element.content, element.source, undefined, app.packageInfos);
 
                     // HINT: pathTo MUST be read after elementParser.parse, because of dynamic paths
                     // Add all other options after parse too, in case of a custom plugin need to modify params.

--- a/lib/parsers/api_param.js
+++ b/lib/parsers/api_param.js
@@ -37,7 +37,7 @@ var regExp = {
     wName: {
         b:               '(\\[?\\s*',                       // 5 optional optional-marker
         name:                '([a-zA-Z0-9\\:\\.\\/\\\\_-]+',   // 6
-            withArray:           '(?:\\[[a-zA-Z0-9\\.\\/\\\\_-]*\\])?)', // https://github.com/apidoc/apidoc-core/pull/4
+        withArray:           '(?:\\[[a-zA-Z0-9\\.\\/\\\\_-]*\\])?)', // https://github.com/apidoc/apidoc-core/pull/4
         oDefaultValue: {                                    // optional defaultValue
             b:               '(?:\\s*=\\s*(?:',             // starting with '=', optional surrounding spaces
             withDoubleQuote:     '"([^"]*)"',               // 7
@@ -81,11 +81,8 @@ function parse(content, source, defaultGroup, packageInfos) {
 
     var allowedValues = matches[4];
     if (allowedValues) {
-        if (packageInfos && packageInfos.parameters) {
-            var overrideAllowedValues = packageInfos.parameters[matches[6]];
-            if (overrideAllowedValues) {
-                allowedValues = overrideAllowedValues.allowedValues;
-            }
+        if (hasOverloadedAllowedValues(packageInfos, matches[6])) {
+            allowedValues =  packageInfos.parameters[matches[6]].allowedValues;
         } else {
             var regExp;
             if (allowedValues.charAt(0) === '"')
@@ -104,6 +101,13 @@ function parse(content, source, defaultGroup, packageInfos) {
         }
     }
 
+    var defaultValues = matches[7] || matches[8] || matches[9];
+    if (defaultValues) {
+        if (hasOverloadedDefaultValues(packageInfos, matches[6])) {
+            defaultValues = packageInfos.parameters[matches[6]].defaultValue;
+        }
+    }
+
     // Replace Unicode Linebreaks in description
     if (matches[10])
         matches[10] = matches[10].replace(/\uffff/g, '\n');
@@ -118,7 +122,7 @@ function parse(content, source, defaultGroup, packageInfos) {
         allowedValues: allowedValues,
         optional     : (matches[5] && matches[5][0] === '[') ? true : false,
         field        : matches[6],
-        defaultValue : matches[7] || matches[8] || matches[9],
+        defaultValue : defaultValues,
         description  : unindent(matches[10] || '')
     };
 }
@@ -129,6 +133,18 @@ function path() {
 
 function getGroup() {
     return group;
+}
+
+function hasOverloadedAllowedValues(packageInfos, field) {
+    return hasParameterValue(packageInfos, field) && packageInfos.parameters[field].allowedValues;
+}
+
+function hasOverloadedDefaultValues(packageInfos, field) {
+    return hasParameterValue(packageInfos, field) && packageInfos.parameters[field].defaultValue;
+}
+
+function hasParameterValue(packageInfos, field) {
+    return packageInfos && packageInfos.parameters && packageInfos.parameters[field];
 }
 
 /**

--- a/lib/parsers/api_param.js
+++ b/lib/parsers/api_param.js
@@ -68,7 +68,7 @@ var allowedValuesWithDoubleQuoteRegExp = new RegExp(/\"[^\"]*[^\"]\"/g);
 var allowedValuesWithQuoteRegExp = new RegExp(/\'[^\']*[^\']\'/g);
 var allowedValuesRegExp = new RegExp(/[^,\s]+/g);
 
-function parse(content, source, packageInfos, defaultGroup) {
+function parse(content, source, defaultGroup, packageInfos) {
     content = trim(content);
 
     // replace Linebreak with Unicode
@@ -81,7 +81,7 @@ function parse(content, source, packageInfos, defaultGroup) {
 
     var allowedValues = matches[4];
     if (allowedValues) {
-        if (packageInfos.parameters) {
+        if (packageInfos && packageInfos.parameters) {
             var overrideAllowedValues = packageInfos.parameters[matches[6]];
             if (overrideAllowedValues) {
                 allowedValues = overrideAllowedValues.allowedValues;

--- a/lib/parsers/api_param.js
+++ b/lib/parsers/api_param.js
@@ -68,7 +68,7 @@ var allowedValuesWithDoubleQuoteRegExp = new RegExp(/\"[^\"]*[^\"]\"/g);
 var allowedValuesWithQuoteRegExp = new RegExp(/\'[^\']*[^\']\'/g);
 var allowedValuesRegExp = new RegExp(/[^,\s]+/g);
 
-function parse(content, source, defaultGroup) {
+function parse(content, source, packageInfos, defaultGroup) {
     content = trim(content);
 
     // replace Linebreak with Unicode
@@ -81,21 +81,27 @@ function parse(content, source, defaultGroup) {
 
     var allowedValues = matches[4];
     if (allowedValues) {
-        var regExp;
-        if (allowedValues.charAt(0) === '"')
-            regExp = allowedValuesWithDoubleQuoteRegExp;
-        else if (allowedValues.charAt(0) === '\'')
-            regExp = allowedValuesWithQuoteRegExp;
-        else
-            regExp = allowedValuesRegExp;
+        if (packageInfos.parameters) {
+            var overrideAllowedValues = packageInfos.parameters[matches[6]];
+            if (overrideAllowedValues) {
+                allowedValues = overrideAllowedValues.allowedValues;
+            }
+        } else {
+            var regExp;
+            if (allowedValues.charAt(0) === '"')
+                regExp = allowedValuesWithDoubleQuoteRegExp;
+            else if (allowedValues.charAt(0) === '\'')
+                regExp = allowedValuesWithQuoteRegExp;
+            else
+                regExp = allowedValuesRegExp;
 
-        var allowedValuesMatch;
-        var list = [];
-
-        while ( (allowedValuesMatch = regExp.exec(allowedValues)) ) {
-            list.push(allowedValuesMatch[0]);
+            var allowedValuesMatch;
+            var list = [];
+            while ( (allowedValuesMatch = regExp.exec(allowedValues)) ) {
+                list.push(allowedValuesMatch[0]);
+            }
+            allowedValues = list;
         }
-        allowedValues = list;
     }
 
     // Replace Unicode Linebreaks in description

--- a/test/parser_api_param_test.js
+++ b/test/parser_api_param_test.js
@@ -99,12 +99,15 @@ describe('Parser: apiParam', function() {
         done();
     });
 
-    it('case 2: should override allowed values from packageInfos', function(done) {
+    it('case 2: should override allowed and default values from packageInfos', function(done) {
         var packageInfos = {
             "parameters": {
                 "\\MyClass\\field.user_first-name": {
                     "allowedValues": [
-                        "my_value"
+                        "my_allowed_value"
+                    ],
+                    "defaultValue": [
+                        "my_default_value"
                     ]
                 }
             }
@@ -115,10 +118,10 @@ describe('Parser: apiParam', function() {
             group: 'MyGroup',
             type: '\\Object\\String.uni-code_char[]',
             size: '1..10',
-            allowedValues: [ 'my_value' ],
+            allowedValues: [ 'my_allowed_value' ],
             optional: true,
             field: '\\MyClass\\field.user_first-name',
-            defaultValue: 'John Doe',
+            defaultValue: [ 'my_default_value' ],
             description: 'Some description.'
         });
         done();

--- a/test/parser_api_param_test.js
+++ b/test/parser_api_param_test.js
@@ -86,7 +86,7 @@ describe('Parser: apiParam', function() {
                 defaultValue: 'John_Doe',
                 description: 'Some description.'
             }
-        },
+        }
     ];
 
     // create
@@ -95,6 +95,31 @@ describe('Parser: apiParam', function() {
             var parsed = parser.parse(testCase.content);
             (parsed !== null).should.equal(true, 'Title: ' + testCase.title + ', Source: ' + testCase.content);
             parsed.should.eql(testCase.expected);
+        });
+        done();
+    });
+
+    it('case 2: should override allowed values from packageInfos', function(done) {
+        var packageInfos = {
+            "parameters": {
+                "\\MyClass\\field.user_first-name": {
+                    "allowedValues": [
+                        "my_value"
+                    ]
+                }
+            }
+        };
+        
+        var parsed = parser.parse(testCases[2].content, undefined, undefined, packageInfos);
+        parsed.should.eql({
+            group: 'MyGroup',
+            type: '\\Object\\String.uni-code_char[]',
+            size: '1..10',
+            allowedValues: [ 'my_value' ],
+            optional: true,
+            field: '\\MyClass\\field.user_first-name',
+            defaultValue: 'John Doe',
+            description: 'Some description.'
         });
         done();
     });


### PR DESCRIPTION
Hi,

We would like to override the 'allowed and default values' in parameter section (@apiParam) with values set in the apidoc.json file.

```
{
  ...
  "parameters": {
    "my_parameter": {
      "allowedValues" : ["my_allowed_value1", "my_allowed_value2"]
    },
    "my_other_parameter": {
      "defaultValue" : "my_default_value"
    }
  }
}
```

We propose this solution but we are not sure about it.
