### PR TITLE
@apiParam should not leak Unicode linebreaks

### DIFF
--- a/lib/parsers/api_param.js
+++ b/lib/parsers/api_param.js
@@ -79,6 +79,13 @@ function parse(content, source, defaultGroup) {
     if ( ! matches)
         return null;
 
+    // reverse Unicode Linebreaks
+    matches.forEach(function (val, index, array) {
+        if (val) {
+            array[index] = val.replace(/\uffff/g, '\n');
+        }
+    });
+
     var allowedValues = matches[4];
     if (allowedValues) {
         var regExp;
@@ -97,10 +104,6 @@ function parse(content, source, defaultGroup) {
         }
         allowedValues = list;
     }
-
-    // Replace Unicode Linebreaks in description
-    if (matches[10])
-        matches[10] = matches[10].replace(/\uffff/g, '\n');
 
     // Set global group variable
     group = matches[1] || defaultGroup || 'Parameter';


### PR DESCRIPTION
Instead of only removing Unicode linebreaks in the description with this change they are removed from all the fields.

Fixes https://github.com/apidoc/apidoc-core/issues/39
