### PR TITLE
Make "fallback" version configurable

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -110,7 +110,8 @@ var defaultPackageInfos = {
     description: '',
     name       : '',
     sampleUrl  : false,
-    version    : '0.0.0'
+    version    : '0.0.0',
+    defaultVersion: '0.0.0'
 };
 
 // Simple logger interace

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -72,7 +72,7 @@ Worker.prototype.process = function(parsedFiles, parsedFilenames, packageInfos) 
                     block.local.url = '';
 
                 if ( ! block.local.version)
-                    block.local.version = '0.0.0';
+                    block.local.version = packageInfos.defaultVersion;
 
                 if ( ! block.local.filename)
                     block.local.filename = parsedFilenames[fileIndex];

--- a/lib/workers/api_group.js
+++ b/lib/workers/api_group.js
@@ -31,7 +31,7 @@ function preProcess(parsedFiles, filenames, packageInfos, target) {
         parsedFile.forEach(function(block) {
             if (block.global[source]) {
                 var name = block.global[source].name;
-                var version = block.version || '0.0.0';
+                var version = block.version || packageInfos.defaultVersion;
 
                 if ( ! result[target][name])
                     result[target][name] = {};
@@ -94,7 +94,7 @@ function postProcess(parsedFiles, filenames, preProcess, packageInfos, source, t
                 return;
 
             var name = block.local[target];
-            var version = block.version || '0.0.0';
+            var version = block.version || packageInfos.defaultVersion;
             var matchedData = {};
 
             if ( ! preProcess[source] || ! preProcess[source][name]) {
@@ -127,7 +127,7 @@ else {
             } else {
                 // find nearest matching version
                 var foundIndex = -1;
-                var lastVersion = '0.0.0';
+                var lastVersion = packageInfos.defaultVersion;
 
                 var versionKeys = Object.keys(preProcess[source][name]);
                 versionKeys.forEach(function(currentVersion, versionIndex) {

--- a/lib/workers/api_param_title.js
+++ b/lib/workers/api_param_title.js
@@ -30,7 +30,7 @@ function preProcess(parsedFiles, filenames, packageInfos, target) {
         parsedFile.forEach(function(block) {
             if (block.global[source]) {
                 var name = block.global[source].name;
-                var version = block.version || '0.0.0';
+                var version = block.version || packageInfos.defaultVersion;
 
                 if ( ! result[target][name])
                     result[target][name] = {};
@@ -76,7 +76,7 @@ function postProcess(parsedFiles, filenames, preProcess, packageInfos, source, t
 
                 params.forEach(function(definition) {
                     var name = definition.group;
-                    var version = block.version || '0.0.0';
+                    var version = block.version || packageInfos.defaultVersion;
                     var matchedData = {};
 
                     if ( ! preProcess[source] || ! preProcess[source][name]) {
@@ -109,7 +109,7 @@ else {
                     } else {
                         // find nearest matching version
                         var foundIndex = -1;
-                        var lastVersion = '0.0.0';
+                        var lastVersion = packageInfos.defaultVersion;
 
                         var versionKeys = Object.keys(preProcess[source][name]);
                         versionKeys.forEach(function(currentVersion, versionIndex) {

--- a/lib/workers/api_permission.js
+++ b/lib/workers/api_permission.js
@@ -30,7 +30,7 @@ function preProcess(parsedFiles, filenames, packageInfos, target) {
         parsedFile.forEach(function(block) {
             if (block.global[source]) {
                 var name = block.global[source].name;
-                var version = block.version || '0.0.0';
+                var version = block.version || packageInfos.defaultVersion;
 
                 if ( ! result[target][name])
                     result[target][name] = {};
@@ -71,7 +71,7 @@ function postProcess(parsedFiles, filenames, preProcess, packageInfos, source, t
             var newPermissions = [];
             block.local[target].forEach(function(definition) {
                 var name = definition.name;
-                var version = block.version || '0.0.0';
+                var version = block.version || packageInfos.defaultVersion;
                 var matchedData = {};
 
                 if ( ! preProcess[source] || ! preProcess[source][name]) {
@@ -105,7 +105,7 @@ else {
                 } else {
                     // find nearest matching version
                     var foundIndex = -1;
-                    var lastVersion = '0.0.0';
+                    var lastVersion = packageInfos.defaultVersion;
 
                     var versionKeys = Object.keys(preProcess[source][name]);
                     versionKeys.forEach(function(currentVersion, versionIndex) {

--- a/lib/workers/api_use.js
+++ b/lib/workers/api_use.js
@@ -31,7 +31,7 @@ function preProcess(parsedFiles, filenames, packageInfos, target) {
         parsedFile.forEach(function(block) {
             if (block.global[source]) {
                 var name = block.global[source].name;
-                var version = block.version || '0.0.0';
+                var version = block.version || packageInfos.defaultVersion;
 
                 if ( ! result[target][name])
                     result[target][name] = {};
@@ -71,7 +71,7 @@ function postProcess(parsedFiles, filenames, preProcess, packageInfos, source, t
 
             block.local[target].forEach(function(definition) {
                 var name = definition.name;
-                var version = block.version || '0.0.0';
+                var version = block.version || packageInfos.defaultVersion;
 
                 if ( ! preProcess[source] || ! preProcess[source][name]) {
                     throw new WorkerError('Referenced groupname does not exist / it is not defined with @apiDefine.',
@@ -93,7 +93,7 @@ function postProcess(parsedFiles, filenames, preProcess, packageInfos, source, t
                 } else {
                     // find nearest matching version
                     var foundIndex = -1;
-                    var lastVersion = '0.0.0';
+                    var lastVersion = packageInfos.defaultVersion;
 
                     var versionKeys = Object.keys(preProcess[source][name]);
                     versionKeys.forEach(function(currentVersion, versionIndex) {


### PR DESCRIPTION
In situations where a block does not define a version explicitly apidocsjs falls back to '0.0.0'.
With this patch the default version can be configured using 'defaultVersion' property in apidoc.json
