### PR TITLE
Fix glob.sync throwing when it can't access a directory

### DIFF
--- a/lib/plugin_loader.js
+++ b/lib/plugin_loader.js
@@ -44,7 +44,12 @@ PluginLoader.prototype.detectPugins = function(dir) {
 
     // Search from the given dir up to root.
     // Every dir start with "apidoc-plugin-", because for the tests of apidoc-plugin-test.
-    var plugins = glob.sync(dir + '/apidoc-plugin-*');
+    try {
+        var plugins = glob.sync(dir + '/apidoc-plugin-*');
+    } catch( e ) {
+        return
+    }
+    
     if (plugins.length === 0) {
         dir = path.join(dir, '..');
         if (dir === '/' || dir.substr(1) === ':\\')


### PR DESCRIPTION
This causes errors in environments where your program doesn't run as root and can't access the full directory tree
