### PR TITLE
add possibility to document an array without name

### DIFF
--- a/lib/parsers/api_param.js
+++ b/lib/parsers/api_param.js
@@ -35,8 +35,8 @@ var regExp = {
         e:               '\\s*\\}\\s*)?'                    // ending with '}', optional surrounding spaces
     },
     wName: {
-        b:               '(\\[?\\s*',                       // 5 optional optional-marker
-        name:                '([a-zA-Z0-9\\:\\.\\/\\\\_-]+',   // 6
+        b:               '((?:\\[?\\s*)(?!\\])\\s*',                       // 5 optional optional-marker
+        name:                '((?:(?:\\[\\])?[a-zA-Z0-9\\:\\.\\/\\\\_-]+|\\[\\])',   // 6 allow to document an array (name field as [])
             withArray:           '(?:\\[[a-zA-Z0-9\\.\\/\\\\_-]*\\])?)', // https://github.com/apidoc/apidoc-core/pull/4
         oDefaultValue: {                                    // optional defaultValue
             b:               '(?:\\s*=\\s*(?:',             // starting with '=', optional surrounding spaces
@@ -110,7 +110,7 @@ function parse(content, source, defaultGroup) {
         type         : matches[2],
         size         : matches[3],
         allowedValues: allowedValues,
-        optional     : (matches[5] && matches[5][0] === '[') ? true : false,
+        optional     : !!(matches[5] && matches[5][0] === '[' && matches[5][1] !== ']'),
         field        : matches[6],
         defaultValue : matches[7] || matches[8] || matches[9],
         description  : unindent(matches[10] || '')

--- a/test/parser_api_param_test.js
+++ b/test/parser_api_param_test.js
@@ -45,14 +45,14 @@ describe('Parser: apiParam', function() {
         {
             title: 'All options, with optional defaultValue',
             content: ' ( MyGroup ) { \\Object\\String.uni-code_char[] { 1..10 } = \'abc\', \'def\' }  ' +
-                     '[ \\MyClass\\field.user_first-name = \'John Doe\' ] Some description.',
+                     '[ []\\MyClass\\field.user_first-name = \'John Doe\' ] Some description.',
             expected: {
                 group: 'MyGroup',
                 type: '\\Object\\String.uni-code_char[]',
                 size: '1..10',
                 allowedValues: [ '\'abc\'', '\'def\'' ],
                 optional: true,
-                field: '\\MyClass\\field.user_first-name',
+                field: '[]\\MyClass\\field.user_first-name',
                 defaultValue: 'John Doe',
                 description: 'Some description.'
             }
@@ -60,14 +60,14 @@ describe('Parser: apiParam', function() {
         {
             title: 'All options, without optional-marker',
             content: ' ( MyGroup ) { \\Object\\String.uni-code_char[] { 1..10 } = \'abc\', \'def\' }  ' +
-                     '\\MyClass\\field.user_first-name = \'John Doe\' Some description.',
+                     '[]\\MyClass\\field.user_first-name = \'John Doe\' Some description.',
             expected: {
                 group: 'MyGroup',
                 type: '\\Object\\String.uni-code_char[]',
                 size: '1..10',
                 allowedValues: [ '\'abc\'', '\'def\'' ],
                 optional: false,
-                field: '\\MyClass\\field.user_first-name',
+                field: '[]\\MyClass\\field.user_first-name',
                 defaultValue: 'John Doe',
                 description: 'Some description.'
             }


### PR DESCRIPTION
Add ability to name param (success param) as `[]` to clearly document an array (when a response is a json list for example).
For example, when a response is a JSON list:
`@apiSuccess {Array} []`
`@apiSuccess {String} [].hello`
