### PR TITLE
Added support for private APIs

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -410,8 +410,16 @@ Parser.prototype._findBlockWithApiGetIndex = function(blocks) {
     for (var i = 0; i < blocks.length; i += 1) {
         var found = false;
         for (var j = 0; j < blocks[i].length; j += 1) {
+            // check apiIgnore
             if (blocks[i][j].name.substr(0, 9) === 'apiignore') {
                 app.log.debug('apiIgnore found in block: ' + i);
+                found = false;
+                break;
+            }
+
+            // check app.options.apiprivate and apiPrivate
+            if (!app.options.apiprivate && blocks[i][j].name.substr(0, 10) === 'apiprivate') {
+                app.log.debug('private flag is set to false and apiPrivate found in block: ' + i);
                 found = false;
                 break;
             }


### PR DESCRIPTION
Added @apiPrivate to support the ability to specify
if an API is a private API.  apidoc now also has a
--private false|true parameter on the command line
that defaults to false.  If false, it does not include
any API block that contains @apiPrivate.  If true, it
will include the API (assuming the API is also not marked
as @apiIgnore).
