### PR TITLE
fix unit test error on macOS because line ending on macOS is '\r'

### DIFF
--- a/test/apidoc_test.js
+++ b/test/apidoc_test.js
@@ -94,7 +94,8 @@ describe('apiDoc full parse', function() {
         });
 
         api = apidoc.parse({
-            src: exampleBasePath + '/src/'
+            src: exampleBasePath + '/src/',
+            lineEnding: '\n'
         });
 
         if (api === false)


### PR DESCRIPTION
On macOS default line ending is '\r', this make unit test "memory should compare to fixtures" fail.