### PR TITLE
Add support for plugins in scoped modules

### DIFF
--- a/lib/plugin_loader.js
+++ b/lib/plugin_loader.js
@@ -15,11 +15,11 @@ function PluginLoader(_app) {
     self.plugins = {};
 
     // Try to load global apidoc-plugins (if apidoc is installed locally it tries only local)
-    this.detectPugins(__dirname);
-
+    this.detectPlugins(__dirname);
+    
     // Try to load local apidoc-plugins
-    this.detectPugins( path.join(process.cwd(), '/node_modules') );
-
+    this.detectPlugins( path.join(process.cwd(), '/node_modules') );
+    
     if (Object.keys(this.plugins).length === 0)
         app.log.debug('No plugins found.');
 
@@ -39,17 +39,19 @@ module.exports = PluginLoader;
  * Detect modules start with "apidoc-plugin-".
  * Search up to root until found a plugin.
  */
-PluginLoader.prototype.detectPugins = function(dir) {
+PluginLoader.prototype.detectPlugins = function(dir) {
     var self = this;
 
     // Search from the given dir up to root.
     // Every dir start with "apidoc-plugin-", because for the tests of apidoc-plugin-test.
-    var plugins = glob.sync(dir + '/apidoc-plugin-*');
+    var plugins = glob.sync(dir + '/apidoc-plugin-*')
+      .concat(glob.sync(dir + '/@*/apidoc-plugin-*'));
+    
     if (plugins.length === 0) {
         dir = path.join(dir, '..');
         if (dir === '/' || dir.substr(1) === ':\\')
             return;
-        return this.detectPugins(dir);
+        return this.detectPlugins(dir);
     }
 
     var offset = dir.length + 1;


### PR DESCRIPTION
Added support for apidoc-plugins in a scoped modules. In addition to checking `node_modules/` for modules with the name `apidoc-plugin-*`, scoped modules (modules beginning with @) are also checked for `apidoc-plugin-*`.
Fixed a misspelling in the plugin_loader.