### PR TITLE
Add @apiDeprecated support

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -76,7 +76,8 @@ var app = {
         apisuccessexample        : './parsers/api_success_example.js',
         apiuse                   : './parsers/api_use.js',
         apiversion               : './parsers/api_version.js',
-        apisamplerequest         : './parsers/api_sample_request.js'
+        apisamplerequest         : './parsers/api_sample_request.js',
+        apideprecated            : './parsers/api_deprecated.js'
     },
     workers: {
         apierrorstructure        : './workers/api_error_structure.js',

--- a/lib/parsers/api_deprecated.js
+++ b/lib/parsers/api_deprecated.js
@@ -1,0 +1,35 @@
+var trim     = require('../utils/trim');
+var unindent = require('../utils/unindent');
+
+function parse(content) {
+    var deprecated = trim(content);
+
+    if (deprecated.length > 0) {
+        var group = deprecated.split(' ')[0];
+        group = group.charAt(0).toUpperCase() + group.slice(1);
+        var name = deprecated.substr(deprecated.indexOf(' ') + 1);
+        var url = name.replace(/(\s+)/g, '_').replace(/\'/g, '_');
+        return {
+            deprecated: {
+                group: group,
+                name: name,
+                url: url
+            }
+        };
+    }
+
+    return {
+        deprecated: {
+            url: null
+        }
+    };
+}
+
+/**
+ * Exports
+ */
+module.exports = {
+    parse         : parse,
+    path          : 'local',
+    method        : 'insert'
+};

--- a/lib/parsers/api_deprecated.js
+++ b/lib/parsers/api_deprecated.js
@@ -1,5 +1,4 @@
 var trim     = require('../utils/trim');
-var unindent = require('../utils/unindent');
 
 function parse(content) {
     var deprecated = trim(content);


### PR DESCRIPTION
Added @apiDeprecated support in order to add the possibility to deprecate an api in documentation.

This pull request need to be accepted in order to create a pull-request in apidoc project with the template part that represent in documentation the api deprecation.

The @apiDeprecated tag accept two optional parameters: 
the alternative api group and api name, needed to create the link on documentation template.
es:

```
@apiDeprecated

or

@apiDeprecated apiGroup apiName
```