### PR TITLE
@apiDeprecated

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -76,7 +76,8 @@ var app = {
         apisuccessexample        : './parsers/api_success_example.js',
         apiuse                   : './parsers/api_use.js',
         apiversion               : './parsers/api_version.js',
-        apisamplerequest         : './parsers/api_sample_request.js'
+        apisamplerequest         : './parsers/api_sample_request.js',
+        apideprecated            : './parsers/api_deprecated.js'
     },
     workers: {
         apierrorstructure        : './workers/api_error_structure.js',

--- a/lib/parsers/api_deprecated.js
+++ b/lib/parsers/api_deprecated.js
@@ -1,0 +1,35 @@
+var trim     = require('../utils/trim');
+var unindent = require('../utils/unindent');
+
+function parse(content) {
+    var deprecated = trim(content);
+
+    if (deprecated.length > 0) {
+        var group = deprecated.split(' ')[0];
+        group = group.charAt(0).toUpperCase() + group.slice(1);
+        var name = deprecated.substr(deprecated.indexOf(' ') + 1);
+        var url = name.replace(/(\s+)/g, '_').replace(/\'/g, '_');
+        return {
+            deprecated: {
+                group: group,
+                name: name,
+                url: url
+            }
+        };
+    }
+
+    return {
+        deprecated: {
+            url: null
+        }
+    };
+}
+
+/**
+ * Exports
+ */
+module.exports = {
+    parse         : parse,
+    path          : 'local',
+    method        : 'insert'
+};

--- a/lib/parsers/api_deprecated.js
+++ b/lib/parsers/api_deprecated.js
@@ -1,5 +1,4 @@
 var trim     = require('../utils/trim');
-var unindent = require('../utils/unindent');
 
 function parse(content) {
     var deprecated = trim(content);

--- a/lib/parsers/api_deprecated.js
+++ b/lib/parsers/api_deprecated.js
@@ -2,24 +2,28 @@ var trim     = require('../utils/trim');
 
 function parse(content) {
     var deprecated = trim(content);
+    var url, text, name, group;
 
+    //  if i have arguments
     if (deprecated.length > 0) {
-        var group = deprecated.split(' ')[0];
-        group = group.charAt(0).toUpperCase() + group.slice(1);
-        var name = deprecated.substr(deprecated.indexOf(' ') + 1);
-        var url = name.replace(/(\s+)/g, '_').replace(/\'/g, '_');
-        return {
-            deprecated: {
-                group: group,
-                name: name,
-                url: url
-            }
-        };
+         // if i have (#group:name) argunents
+        if (deprecated.search(/\(#(.*):(.*)\)/) >= 0) {
+            var groupName = deprecated.substring(deprecated.search(/\(#(.*):(.*)\)/) + 2, deprecated.length - 1);
+            group = groupName.split(':')[0];
+            group = group.charAt(0).toUpperCase() + group.slice(1);
+            name = groupName.split(':')[1];
+            url = group + '-' + name.replace(/(\s+)/g, '_').replace(/\'/g, '_');
+            deprecated = deprecated.substring(0, deprecated.search(/\(#(.*):(.*)\)/));
+        }
+        text = trim(deprecated);
     }
 
     return {
         deprecated: {
-            url: null
+            url: url,
+            text: text,
+            name: name,
+            group: group
         }
     };
 }


### PR DESCRIPTION
Hi, 
i've modified the @apiDeprecated tag support as you suggested in the previous PR  https://github.com/apidoc/apidoc-core/pull/52

Now is so

```@apiDeprecated``` shows only the Text DEPRECATED.
```@apiDeprecated Some text shows``` Text DEPRECATED and some text.
```@apiDeprecated Some text (#Group:Name)``` shows Text DEPRECATED and some text with the link to the given group+name.


@rottmann let me know if now is ok for you.