### PR TITLE
HTML-Encode Examples

### DIFF
--- a/lib/parsers/api_example.js
+++ b/lib/parsers/api_example.js
@@ -28,7 +28,7 @@ function parse(content, source) {
         return null;
     
     Encoder = require('node-html-encoder').Encoder;
-	var encoder = new Encoder('entity');
+    var encoder = new Encoder('entity');
 		
     return {
         title  : title,

--- a/lib/parsers/api_example.js
+++ b/lib/parsers/api_example.js
@@ -26,10 +26,13 @@ function parse(content, source) {
 
     if (text.length === 0)
         return null;
-
+    
+    Encoder = require('node-html-encoder').Encoder;
+	var encoder = new Encoder('entity');
+		
     return {
         title  : title,
-        content: unindent(text),
+        content: encoder.htmlEncode(unindent(text)),
         type   : type || 'json'
     };
 }

--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
     "iconv-lite": "^0.4.15",
     "klaw-sync": "^1.0.2",
     "lodash": "~4.17.4",
-    "semver": "~5.3.0"
+    "semver": "~5.3.0",
+    "node-html-encoder": "^0.0.2"
   },
   "devDependencies": {
     "apidoc-example": "*",


### PR DESCRIPTION
If you create an example for any API function that includes XML code, the 'Greater Than' and 'Less Than' symbols aren't encoded and cause your HTML to corrupt.

This change adds a new dependency (node-html-encode) and encodes all special characters within an example to produce valid HTML.