### PR TITLE
update elixir syntax

### DIFF
--- a/lib/languages/ex.js
+++ b/lib/languages/ex.js
@@ -3,7 +3,7 @@
  */
 module.exports = {
     // Find document blocks between '#{' and '#}'
-    docBlocksRegExp: /#*\s?\{\uffff?(.+?)\uffff?(?:\s*)?#+\s?\}/g,
+    docBlocksRegExp: /\#*\{\uffff?(.+?)\uffff?(?:\s*)?\#+\}/g,
     // Remove not needed '#' and tabs at the beginning
-    inlineRegExp: /^(\s*)?(#*)[ ]?/gm
+    inlineRegExp: /^(\s*)?(\#*)[ ]?/gm
 };

--- a/lib/languages/ex.js
+++ b/lib/languages/ex.js
@@ -3,7 +3,7 @@
  */
 module.exports = {
     // Find document blocks between '#{' and '#}'
-    docBlocksRegExp: /\#*\{\uffff?(.+?)\uffff?(?:\s*)?\#+\}/g,
+    docBlocksRegExp: /#*\s?\{\uffff?(.+?)\uffff?(?:\s*)?#+\s?\}/g,
     // Remove not needed '#' and tabs at the beginning
-    inlineRegExp: /^(\s*)?(\#*)[ ]?/gm
+    inlineRegExp: /^(\s*)?(#*)[ ]?/gm
 };

--- a/lib/languages/ex.js
+++ b/lib/languages/ex.js
@@ -3,7 +3,7 @@
  */
 module.exports = {
     // Find document blocks between '#{' and '#}'
-    docBlocksRegExp: /\#*\{\uffff?(.+?)\uffff?(?:\s*)?\#+\}/g,
+    docBlocksRegExp: /\#*\s?\{\uffff?(.+?)\uffff?(?:\s*)?\#+\s?\}/g,
     // Remove not needed '#' and tabs at the beginning
     inlineRegExp: /^(\s*)?(\#*)[ ]?/gm
 };

--- a/lib/languages/ex.js
+++ b/lib/languages/ex.js
@@ -2,10 +2,8 @@
  * Elixir
  */
 module.exports = {
-    // Find document blocks in heredocs that are arguments of the @apidoc
-    // module attribute. Elixir heredocs can be enclosed between """ and """ or
-    // between ''' and '''. Heredocs in ~s and ~S sigils are also supported.
-    docBlocksRegExp: /@apidoc\s*(~[sS])?"""\uffff?(.+?)\uffff?(?:\s*)?"""|@apidoc\s*(~[sS])?'''\uffff?(.+?)\uffff?(?:\s*)?'''/g,
-    // Remove not needed tabs at the beginning
-    inlineRegExp: /^(\t*)?/gm
+    // Find document blocks between '#{' and '#}'
+    docBlocksRegExp: /\#*\{\uffff?(.+?)\uffff?(?:\s*)?\#+\}/g,
+    // Remove not needed '#' and tabs at the beginning
+    inlineRegExp: /^(\s*)?(\#*)[ ]?/gm
 };


### PR DESCRIPTION
update elixir's syntax so that it does not use module attributes.. as discussed in https://github.com/apidoc/apidoc/issues/640 and issue referenced in that issue (https://github.com/rrrene/credo/issues/291), we need to use alternative instead of the module attribute for describing api documentation. Some of us put warnings as errors and unused module attributes produce compiler warnings.