### PR TITLE
Perl: handle =head[1-4] and =item as well as =pod

### DIFF
--- a/lib/languages/pm.js
+++ b/lib/languages/pm.js
@@ -4,6 +4,8 @@
 module.exports = {
     // find document blocks between '#**' and '#*'
     // or between '=pod' and '=cut'
+    // or one of '=head1', '=head2', '=head3', '=head4', or '=item'
+    //     instead of '=pod'
     docBlocksRegExp: /#\*\*\uffff?(.+?)\uffff?(?:\s*)?#\*|=(?:pod|head[1-4]|item)\uffff?(.+?)\uffff?(?:\s*)?=cut/g,
     // remove not needed ' # ' and tabs at the beginning
     inlineRegExp: /^(\s*)?(#)[ ]?/gm

--- a/lib/languages/pm.js
+++ b/lib/languages/pm.js
@@ -4,7 +4,7 @@
 module.exports = {
     // find document blocks between '#**' and '#*'
     // or between '=pod' and '=cut'
-    docBlocksRegExp: /#\*\*\uffff?(.+?)\uffff?(?:\s*)?#\*|=pod\uffff?(.+?)\uffff?(?:\s*)?=cut/g,
+    docBlocksRegExp: /#\*\*\uffff?(.+?)\uffff?(?:\s*)?#\*|=(?:pod|head[1-4]|item)\uffff?(.+?)\uffff?(?:\s*)?=cut/g,
     // remove not needed ' # ' and tabs at the beginning
     inlineRegExp: /^(\s*)?(#)[ ]?/gm
 };


### PR DESCRIPTION
In Perl modules, =item or =head* are commonly used for documenting methods/functions

I'm not sure how to do unit testing for this though, would be grateful if anyone shown me. I only tested locally, aka "works on my machine". 