### PR TITLE
Fix the regex parsing for valueless parameters

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -448,7 +448,7 @@ Parser.prototype.findElements = function(block, filename) {
     block = block.replace(/\n/g, '\uffff');
 
     // Elements start with @
-    var elementsRegExp = /(@(\w*)\s?(.+?)(?=\uffff[\s\*]*@|$))/gm;
+    var elementsRegExp = /(@(\w*)\s?(.*?)(?=\uffff[\s\*]*@|$))/gm;
     var matches = elementsRegExp.exec(block);
     while (matches) {
         var element = {


### PR DESCRIPTION
The `@apiPrivate` parameter does not take any value, and the `@apiDeprecated` parameter has an optional value. However, the regular expression in `Parser.prototype.findElements` expects that every parameter has a value. This may lead to the subsequent apiDoc parameter getting matched into the valueless parameter, removing it from the final generated apiDocs.

Switching the regular expression from `(.+?)` to `(.*?)` allows the parameter's value to be optional.

I've used regex101.com to demonstrate the matchings.
* The current regular expression, which does not parse valueless parameters correctly: https://regex101.com/r/oC5kK2/6
* The updated regular expression, which does: https://regex101.com/r/NJmi0D/2

In case the examples become unavailable, I used the following apiDocs code to test the regular expression:
```
/**
 * @apiDescription
 * These parameter examples demonstrate how the regular expression incorrectly
 * parses valueless apiDoc parameters. Parameters that either following by
 * a newline or a space and a newline will include any subsequent lines.
 *
 * The apiDoc parser swaps out newlines for the UTF non-character U-FFFF. To
 * avoid complications, the regular expression has been taken verbatim from the
 * parsing code and the human-readable comments here have been appropriately
 * transformed below.  To prevent the regular expression from matching, the
 * at signs have been swapped out for hashes in the human-readable version.
 *
 * @apiPrivate
 * @apiDescription The valueless apiPrivate incorrectly captures this
 * apiDescription parameter. This apiDescription parameter would _not_ be
 * available in the rendered apiDocs.
 *
 * @apiPrivate
 *
 * @apiDescription The valueless apiPrivate followed by two newlines is
 * properly matched.
 *
 * @apiDeprecated [text]
 * @apiDescription A valid apiDeprecated paramater with optional text included.
 * The regular expression matching would terminate correctly.
 *
 * @apiDeprecated
 * @apiDescription The valueless apiDeprecated incorrectly captures this
 * apiDescription parameter.
 *
 * @apiDeprecated 
 * @apiDescription The apiDeprecated followed by a single space and then a
 * newline would also incorrectly captures this apiDescription parameter.
 */
```