### PR TITLE
Modify parser to use first match even if in higher positions.

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -388,7 +388,8 @@ Parser.prototype._findBlocks = function() {
     var regexForFile = this.languages[self.extension] || this.languages['default'];
     var matches = regexForFile.docBlocksRegExp.exec(src);
     while (matches) {
-        var block = matches[2] || matches[1];
+        matches.shift(); // Drop the 0th element which is the full string
+        var block = _.compact(matches)[0]; // Drop nulls and use first actual match
 
         // Reverse Unicode Linebreaks
         block = block.replace(/\uffff/g, '\n');

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apidoc-core",
-  "version": "0.8.3",
+  "version": "0.8.4",
   "description": "Core parser library to generate apidoc result following the apidoc-spec",
   "author": "Peter Rottmann <rottmann@inveris.de>",
   "license": "MIT",


### PR DESCRIPTION
When using Elixir with single quote heredoc syntax, eg
    @apidoc '''
    @api {get} /index
    '''
The docBlocksRegExp match is in the element 4 of the matches array.
An error was being thrown because only elements 1 & 2 were being
checked for a match.

Since a match is guaranteed, otherwise the regular expression would
have returned null and the loop would exit, it seems appropriate to
use the first non-null element of the matches array as a block. The
first element is excluded though, as this always contains the full
string being checked rather than a substring match.