### PR TITLE
Use os.EOL to detect line endings

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -29,7 +29,7 @@ var defaults = {
     parsers: {},
     workers: {},
 
-    lineEnding: detectLineEnding(),
+    lineEnding: os.EOL,
     encoding: 'utf8'
 };
 
@@ -132,15 +132,6 @@ var logger = {
  */
 function getSpecificationVersion() {
     return SPECIFICATION_VERSION;
-}
-
-/**
- * Detect and return OS specific line ending.
- *
- * @returns {String}
- */
-function detectLineEnding() {
-    return os.EOL;
 }
 
 /**

--- a/lib/index.js
+++ b/lib/index.js
@@ -140,11 +140,7 @@ function getSpecificationVersion() {
  * @returns {String}
  */
 function detectLineEnding() {
-    if ( os.platform() === 'win32' )
-        return '\r\n';
-    if ( os.platform() === 'darwin' )
-        return '\r';
-    return '\n';
+    return os.EOL;
 }
 
 /**


### PR DESCRIPTION
This changes the line endings for osx to LF,
This is more inline with modern osx which switched to LF from CR circa 2001