### PR TITLE
Add options.json capability.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -246,6 +246,10 @@ function parse(options) {
             // add apiDoc specification version
             app.packageInfos.generator = app.generator;
 
+            if (app.options.json) {
+                return blocks;
+            }
+
             // api_data
             var apiData = JSON.stringify(blocks, null, 2);
             apiData = apiData.replace(/(\r\n|\n|\r)/g, app.options.lineEnding);


### PR DESCRIPTION
Hello there,

For integration with other systems purpose, I needed to get the doc as JSON instead of getting a stringified version after parsing.

This PR adds a `json` option to the `parse` method. 

Please, let me know what you think of it.

Cheers.