### PR TITLE
Add support to parse blocks of single-line comments on C-like languages (c#,c,c++,javascript,php,...)

### DIFF
--- a/lib/languages/default.js
+++ b/lib/languages/default.js
@@ -1,9 +1,20 @@
 /**
  * C#, Go, Dart, Java, JavaScript, PHP (all DocStyle capable languages)
  */
+// find blocks between '/**' and '*/'
+var cMultilineCommentsRegex = /\/\*\*\uffff?(.+?)\uffff?(?:\s*)?\*\//;
+
+// find all contiguous blocks of single-line comments
+var cSingleLineCommentsRegex = /(\/\/[^\uffff]+)(\uffff\s*\/\/[^\uffff]*)+/;
+
+// combine multiline and single line blocks regular expressions
+var cLikeCommentsRegex = new RegExp (
+    '((' + cMultilineCommentsRegex.source + ')|(' + cSingleLineCommentsRegex.source + '))',
+    'g'
+);
+
 module.exports = {
-    // find document blocks between '#**' and '#*'
-    docBlocksRegExp: /\/\*\*\uffff?(.+?)\uffff?(?:\s*)?\*\//g,
-    // remove not needed ' * ' and tabs at the beginning
-    inlineRegExp: /^(\s*)?(\*)[ ]?/gm
+    docBlocksRegExp: cLikeCommentsRegex,
+    // remove unneeded ' * ', tabs at the beginning and empty single-line comments
+    inlineRegExp: /^\s*((\*)[ ]?\/?)|(\/\/\s*(\-*)?)/gm
 };

--- a/lib/languages/default.js
+++ b/lib/languages/default.js
@@ -9,12 +9,14 @@ var cSingleLineCommentsRegex = /(\/\/[^\uffff]+)(\uffff\s*\/\/[^\uffff]*)+/;
 
 // combine multiline and single line blocks regular expressions
 var cLikeCommentsRegex = new RegExp (
-    '((' + cMultilineCommentsRegex.source + ')|(' + cSingleLineCommentsRegex.source + '))',
-    'g'
+  '((' + cMultilineCommentsRegex.source + ')|(' + cSingleLineCommentsRegex.source + '))',
+  'g'
 );
 
 module.exports = {
     docBlocksRegExp: cLikeCommentsRegex,
     // remove unneeded ' * ', tabs at the beginning and empty single-line comments
-    inlineRegExp: /^\s*((\*)[ ]?\/?)|(\/\/\s*(\-*)?)/gm
+    // also remove lines with // followed by either '-' or more '/'
+    inlineRegExp: /(^\s*((\*)[ ]?\/?))|(^\s*(\/\/\s*([-\/]{2,}))|(^\s*\/\/))/gm
+    //inlineRegExp: /^\s*(((\*)[ ]?\/?)|(\/\/\s*(\-*)?))/gm
 };


### PR DESCRIPTION
The change I've made makes possible to return contiguous lines of single-line comments as a single block.

Regular expression has been splitted for simplicity, but performance when executing regular expression should be fine (apart of having to process more blocks that should get detected).

This change might be appealing to some people, because not everybody uses the /** in their coding standards, so that limits the scope in which this library can be used.

Another possibility is to add a --all-comments or something and then use the new regular expression, but I think it should be simpler to make it the default behaviour.

Example: 

```javascript
 let text = "... imagine this is some sort of text in the file...";
 // @api {get} /user/:id Request User information
 // @apiName GetUser
 // @apiGroup User
 //
 // @apiParam {Number} id Users unique ID.
 //
 // @apiSuccess {String} firstname Firstname of the User.
 // @apiSuccess {String} lastname  Lastname of the User.
 //
function requestUserInformation () { 
    // previous line does not start with  '//'
    // this is another block, not only because of that, but because there are at least two consecutive lines
...
```