### PR TITLE
fix:warn: parser plugin 'apiprivate' not found in block: 1

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -78,7 +78,8 @@ var app = {
         apiuse                   : './parsers/api_use.js',
         apiversion               : './parsers/api_version.js',
         apisamplerequest         : './parsers/api_sample_request.js',
-        apideprecated            : './parsers/api_deprecated.js'
+        apideprecated            : './parsers/api_deprecated.js',
+        apiprivate               : './parsers/api_private.js',
     },
     workers: {
         apierrorstructure        : './workers/api_error_structure.js',

--- a/lib/parsers/api_private.js
+++ b/lib/parsers/api_private.js
@@ -1,0 +1,16 @@
+var trim = require('../utils/trim');
+
+function parse(content) {
+    content = trim(content);
+
+    return content;
+}
+
+/**
+ * Exports
+ */
+module.exports = {
+    parse : parse,
+    path  : 'local',
+    method: 'insert'
+};


### PR DESCRIPTION
fix:when  using @apiPrivate in doc, then has an error:warn: parser plugin 'apiprivate' not found in block: 1