### PR TITLE
Consolidate some worker call options into a single options object par…

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -23,6 +23,8 @@ var defaults = {
     includeFilters: [ '.*\\.(clj|cls|coffee|cpp|cs|dart|erl|exs?|go|groovy|ino?|java|js|jsx|litcoffee|lua|p|php?|pl|pm|py|rb|scala|ts|vue)$' ],
 
     src: path.join(__dirname, '../example/'),
+    //If this is set to false, inherited parts are stored in a "inheritable.json" file with keys referenced from the output json.
+    copyDefinitions: true,
 
     filters: {},
     languages: {},
@@ -180,6 +182,8 @@ function parse(options) {
 
     var parsedFiles = [];
     var parsedFilenames = [];
+    // an object of definitions that can be traversed like so: definitions.source.name.versionName to get the relevant definition.
+    var definitions = {};
 
     try {
         // Log version information
@@ -222,7 +226,7 @@ function parse(options) {
         if (parsedFiles.length > 0) {
             // process transformations and assignments
             app.log.verbose('run worker');
-            worker.process(parsedFiles, parsedFilenames, app.packageInfos);
+            worker.process(parsedFiles, parsedFilenames, app.packageInfos, definitions);
 
             // cleanup
             app.log.verbose('run filter');
@@ -254,9 +258,14 @@ function parse(options) {
             var apiProject = JSON.stringify(app.packageInfos, null, 2);
             apiProject = apiProject.replace(/(\r\n|\n|\r)/g, app.options.lineEnding);
 
+            // Include the definitions of the use blocks within the output data
+            var apiDefinitions = JSON.stringify(definitions, null, 2);
+            apiDefinitions = apiDefinitions.replace(/(\r\n|\n|\r)/g, app.options.lineEnding);
+
             return {
                 data   : apiData,
-                project: apiProject
+                project: apiProject,
+                definitions : apiDefinitions
             };
         }
         return true;

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -59,7 +59,7 @@ Worker.prototype.addWorker = function(name, worker) {
  *
  * @todo Add priority system (if needed), if a plugin need an other operation to be done before.
  */
-Worker.prototype.process = function(parsedFiles, parsedFilenames, packageInfos) {
+Worker.prototype.process = function(parsedFiles, parsedFilenames, packageInfos, definitions) {
     // some smaller operation that are not outsourced to extra workers
     // TODO: add priority system first and outsource them then
     parsedFiles.forEach(function(parsedFile, fileIndex) {
@@ -94,10 +94,11 @@ Worker.prototype.process = function(parsedFiles, parsedFilenames, packageInfos) 
             _.extend(preProcessResults, result);
         }
     });
+    _.extend(definitions, preProcessResults);
     _.each(this.workers, function(worker, name) {
         if (worker.postProcess) {
             app.log.verbose('worker postProcess: ' + name);
-            worker.postProcess(parsedFiles, parsedFilenames, preProcessResults, packageInfos);
+            worker.postProcess(parsedFiles, parsedFilenames, preProcessResults, packageInfos, {copyDefinitions: app.options.copyDefinitions});
         }
     });
 };

--- a/lib/workers/api_error_structure.js
+++ b/lib/workers/api_error_structure.js
@@ -1,5 +1,6 @@
 // Same as @apiUse
 var apiWorker = require('./api_use.js');
+var _      = require('lodash');
 
 // Additional information for error log
 var _messages = {
@@ -29,9 +30,10 @@ function preProcess(parsedFiles, filenames, packageInfos) {
  * @param {String[]} filenames
  * @param {Object[]} preProcess
  * @param {Object}   packageInfos
+ * @param {Object}   options    Contains {bool} copyDefinitions
  */
-function postProcess(parsedFiles, filenames, preProcess, packageInfos) {
-    apiWorker.postProcess(parsedFiles, filenames, preProcess, packageInfos, 'defineErrorStructure', 'errorStructure', _messages);
+function postProcess(parsedFiles, filenames, preProcess, packageInfos, options) {
+    apiWorker.postProcess(parsedFiles, filenames, preProcess, packageInfos, {copyDefinitions: options.copyDefinitions, source: 'defineErrorStructure', target: 'errorStructure', messages: _messages});
 }
 
 /**

--- a/lib/workers/api_error_title.js
+++ b/lib/workers/api_error_title.js
@@ -1,5 +1,6 @@
 // Same as @apiParamTitle
 var apiWorker = require('./api_param_title.js');
+var _ = require('lodash');
 
 // Additional information for error log
 var _messages = {
@@ -29,9 +30,10 @@ function preProcess(parsedFiles, filenames, packageInfos) {
  * @param {String[]} filenames
  * @param {Object[]} preProcess
  * @param {Object}   packageInfos
+ * @param {Object}   options    Contains {bool} copyDefinitions
  */
-function postProcess(parsedFiles, filenames, preProcess, packageInfos) {
-    apiWorker.postProcess(parsedFiles, filenames, preProcess, packageInfos, 'defineErrorTitle', 'error', _messages);
+function postProcess(parsedFiles, filenames, preProcess, packageInfos, options) {
+    apiWorker.postProcess(parsedFiles, filenames, preProcess, packageInfos, {copyDefinitions: options.copyDefinitions, source: 'defineErrorTitle', target: 'error', messages: _messages});
 }
 
 /**

--- a/lib/workers/api_group.js
+++ b/lib/workers/api_group.js
@@ -56,14 +56,13 @@ function preProcess(parsedFiles, filenames, packageInfos, target) {
  * @param {String[]} filenames
  * @param {Object[]} preProcess
  * @param {Object}   packageInfos
- * @param {String}   source       Source path in preProcess-Object
- * @param {String}   target       Relative path to the tree (local.), where the data should be modified.
- * @param {String}   messages
+ * @param {Object}   options       Includes source, target, messages and other options such as copyDefinitions.
  */
-function postProcess(parsedFiles, filenames, preProcess, packageInfos, source, target, messages) {
-    source = source || 'defineGroup';
-    target = target || 'group';
-    messages = messages || _messages;
+function postProcess(parsedFiles, filenames, preProcess, packageInfos, options) {
+    options = options || {};
+    var source = options.source || 'defineGroup';
+    var target = options.target || 'group';
+    var messages = options.messages || _messages;
 
     // set group name if empty
     parsedFiles.forEach(function(parsedFile, parsedFileIndex) {

--- a/lib/workers/api_header_structure.js
+++ b/lib/workers/api_header_structure.js
@@ -1,5 +1,6 @@
 // Same as @apiUse
 var apiWorker = require('./api_use.js');
+var _ = require('lodash');
 
 // Additional information for error log
 var _messages = {
@@ -29,9 +30,10 @@ function preProcess(parsedFiles, filenames, packageInfos) {
  * @param {String[]} filenames
  * @param {Object[]} preProcess
  * @param {Object}   packageInfos
+ * @param {Object}   options    Contains {bool} copyDefinitions
  */
-function postProcess(parsedFiles, filenames, preProcess, packageInfos) {
-    apiWorker.postProcess(parsedFiles, filenames, preProcess, packageInfos, 'defineHeaderStructure', 'headerStructure', _messages);
+function postProcess(parsedFiles, filenames, preProcess, packageInfos, options) {
+    apiWorker.postProcess(parsedFiles, filenames, preProcess, packageInfos, {copyDefinitions: options.copyDefinitions, source: 'defineHeaderStructure', target: 'headerStructure', messages: _messages});
 }
 
 /**

--- a/lib/workers/api_header_title.js
+++ b/lib/workers/api_header_title.js
@@ -1,5 +1,6 @@
 // Same as @apiParamTitle
 var apiWorker = require('./api_param_title.js');
+var _ = require('lodash');
 
 // Additional information for error log
 var _messages = {
@@ -29,9 +30,10 @@ function preProcess(parsedFiles, filenames, packageInfos) {
  * @param {String[]} filenames
  * @param {Object[]} preProcess
  * @param {Object}   packageInfos
+ * @param {Object}   options    Contains {bool} copyDefinitions
  */
-function postProcess(parsedFiles, filenames, preProcess, packageInfos) {
-    apiWorker.postProcess(parsedFiles, filenames, preProcess, packageInfos, 'defineHeaderTitle', 'header', _messages);
+function postProcess(parsedFiles, filenames, preProcess, packageInfos, options) {
+    apiWorker.postProcess(parsedFiles, filenames, preProcess, packageInfos, {copyDefinitions: options.copyDefinitions, source: 'defineHeaderTitle', target: 'header', messages: _messages});
 }
 
 /**

--- a/lib/workers/api_param_title.js
+++ b/lib/workers/api_param_title.js
@@ -1,5 +1,7 @@
 var semver = require('semver');
 var WorkerError = require('../errors/worker_error');
+var _ = require('lodash');
+
 
 // Additional information for error log
 var _messages = {
@@ -55,14 +57,13 @@ function preProcess(parsedFiles, filenames, packageInfos, target) {
  * @param {String[]} filenames
  * @param {Object[]} preProcess
  * @param {Object}   packageInfos
- * @param {String}   source       Source path in preProcess-Object
- * @param {String}   target       Relative path to the tree (local.), where the data should be modified.
- * @param {String}   messages
+ * @param {Object}   options       Includes source, target, messages and other options such as copyDefinitions.
  */
-function postProcess(parsedFiles, filenames, preProcess, packageInfos, source, target, messages) {
-    source = source || 'defineParamTitle';
-    target = target || 'parameter';
-    messages = messages || _messages;
+function postProcess(parsedFiles, filenames, preProcess, packageInfos, options) {
+    options = options || {};
+    var source = options.source || 'defineParamTitle';
+    var target = options.target || 'parameter';
+    var messages = options.messages || _messages;
 
     parsedFiles.forEach(function(parsedFile, parsedFileIndex) {
         parsedFile.forEach(function(block) {

--- a/lib/workers/api_permission.js
+++ b/lib/workers/api_permission.js
@@ -54,14 +54,13 @@ function preProcess(parsedFiles, filenames, packageInfos, target) {
  * @param {String[]} filenames
  * @param {Object[]} preProcess
  * @param {Object}   packageInfos
- * @param {String}   source       Source path in preProcess-Object
- * @param {String}   target       Relative path to the tree (local.), where the data should be modified.
- * @param {String}   messages
+ * @param {Object}   options       Includes source, target, messages and other options such as copyDefinitions.
  */
-function postProcess(parsedFiles, filenames, preProcess, packageInfos, source, target, messages) {
-    source = source || 'definePermission';
-    target = target || 'permission';
-    messages = messages || _messages;
+function postProcess(parsedFiles, filenames, preProcess, packageInfos, options) {
+    options = options || {};
+    var source = options.source || 'definePermission';
+    var target = options.target || 'permission';
+    var messages = options.messages || _messages;
 
     parsedFiles.forEach(function(parsedFile, parsedFileIndex) {
         parsedFile.forEach(function(block) {

--- a/lib/workers/api_structure.js
+++ b/lib/workers/api_structure.js
@@ -1,3 +1,4 @@
+var _ = require('lodash');
 // Same as @apiUse
 var apiWorker = require('./api_use.js');
 
@@ -30,8 +31,8 @@ function preProcess(parsedFiles, filenames, packageInfos) {
  * @param {Object[]} preProcess
  * @param {Object}   packageInfos
  */
-function postProcess(parsedFiles, filenames, preProcess, packageInfos) {
-    apiWorker.postProcess(parsedFiles, filenames, preProcess, packageInfos, 'defineStructure', 'structure', _messages);
+function postProcess(parsedFiles, filenames, preProcess, packageInfos, options) {
+    apiWorker.postProcess(parsedFiles, filenames, preProcess, packageInfos, _.extend(options, {source: 'defineStructure', target: 'structure', messages: _messages}));
 }
 
 /**

--- a/lib/workers/api_success_structure.js
+++ b/lib/workers/api_success_structure.js
@@ -1,3 +1,4 @@
+var _ = require('lodash');
 // Same as @apiUse
 var apiWorker = require('./api_use.js');
 
@@ -29,9 +30,10 @@ function preProcess(parsedFiles, filenames, packageInfos) {
  * @param {String[]} filenames
  * @param {Object[]} preProcess
  * @param {Object}   packageInfos
+ * @param {Object}   options    Contains {bool} copyDefinitions
  */
-function postProcess(parsedFiles, filenames, preProcess, packageInfos) {
-    apiWorker.postProcess(parsedFiles, filenames, preProcess, packageInfos, 'defineSuccessStructure', 'successStructure', _messages);
+function postProcess(parsedFiles, filenames, preProcess, packageInfos, options) {
+    apiWorker.postProcess(parsedFiles, filenames, preProcess, packageInfos, {copyDefinitions: options.copyDefinitions, source: 'defineSuccessStructure', target: 'successStructure', messages: _messages});
 }
 
 /**

--- a/lib/workers/api_success_title.js
+++ b/lib/workers/api_success_title.js
@@ -1,3 +1,4 @@
+var _ = require('lodash');
 // Same as @apiParamTitle
 var apiWorker = require('./api_param_title.js');
 
@@ -29,9 +30,10 @@ function preProcess(parsedFiles, filenames, packageInfos) {
  * @param {String[]} filenames
  * @param {Object[]} preProcess
  * @param {Object}   packageInfos
+ * @param {Object}   options    Contains {bool} copyDefinitions
  */
-function postProcess(parsedFiles, filenames, preProcess, packageInfos) {
-    apiWorker.postProcess(parsedFiles, filenames, preProcess, packageInfos, 'defineSuccessTitle', 'success', _messages);
+function postProcess(parsedFiles, filenames, preProcess, packageInfos, options) {
+    apiWorker.postProcess(parsedFiles, filenames, preProcess, packageInfos, {copyDefinitions: options.copyDefinitions, source: 'defineSuccessTitle', target: 'success', messages: _messages});
 }
 
 /**

--- a/lib/workers/api_use.js
+++ b/lib/workers/api_use.js
@@ -55,20 +55,20 @@ function preProcess(parsedFiles, filenames, packageInfos, target) {
  * @param {String[]} filenames
  * @param {Object[]} preProcess
  * @param {Object}   packageInfos
- * @param {String}   source       Source path in preProcess-Object
- * @param {String}   target       Target path in preProcess-Object (returned result), where the data should be set.
- * @param {String}   messages
+ * @param {Object}   options       Includes source, target, messages and other options such as copyDefinitions.
  */
-function postProcess(parsedFiles, filenames, preProcess, packageInfos, source, target, messages) {
-    source = source || 'define';
-    target = target || 'use';
-    messages = messages || _messages;
+function postProcess(parsedFiles, filenames, preProcess, packageInfos, options) {
+    options = options || {};
+    var source = options.source || 'define';
+    var target = options.target || 'use';
+    var messages = options.messages || _messages;
+
 
     parsedFiles.forEach(function(parsedFile, parsedFileIndex) {
         parsedFile.forEach(function(block) {
             if ( ! block.local[target])
                 return;
-
+            var matchedDefinitionPaths = [];
             block.local[target].forEach(function(definition) {
                 var name = definition.name;
                 var version = block.version || packageInfos.defaultVersion;
@@ -127,9 +127,17 @@ function postProcess(parsedFiles, filenames, preProcess, packageInfos, source, t
                 // TODO: create a cleanup filter
                 delete block.local[target];
 
-                // copy matched elements into parsed block
-                _recursiveMerge(block.local, matchedData);
+                if(options.copyDefinitions) {
+                    // copy matched elements into parsed block
+                    _recursiveMerge(block.local, matchedData);
+                } else{
+                    // If we're not copying definitions, just copy a path of keys to the definition
+                    matchedDefinitionPaths.push([source, name, versionName]);
+                }
             });
+            if(!options.copyDefinitions) {
+                _recursiveMerge(block.local, { use: matchedDefinitionPaths });
+            }
         });
     });
 }

--- a/test/apidoc_test.js
+++ b/test/apidoc_test.js
@@ -95,7 +95,8 @@ describe('apiDoc full parse', function() {
 
         api = apidoc.parse({
             src: exampleBasePath + '/src/',
-            lineEnding: '\n'
+            lineEnding: '\n',
+            copyDefinitions: true
         });
 
         if (api === false)


### PR DESCRIPTION
…ameter. Also include a copyDefinition flag to specify if the user wants to copy all the @apiDefinition blocks into the use calls or not. One might not want to copy all definitions if needing to preserve model relationships.