### PR TITLE
sample values for sampleRequest

### DIFF
--- a/lib/parsers/api_param.js
+++ b/lib/parsers/api_param.js
@@ -47,6 +47,11 @@ var regExp = {
         },
         e:               '\\s*\\]?\\s*)'
     },
+    oDefValue: { // optional sample value: <404>
+        b: '\\s*(?:\\<\\s*', // starting with '<', optional surrounding spaces
+        group: '(.+?)', // 1
+        e: '\\s*\\>\\s*)?', // ending with '>', optional surrounding spaces
+      }, 
     description:         '(.*)?',                           // 10
     e:               '$|@'
 };
@@ -116,7 +121,8 @@ function parse(content, source, defaultGroup) {
         optional     : (matches[5] && matches[5][0] === '[') ? true : false,
         field        : matches[6],
         defaultValue : matches[7] || matches[8] || matches[9],
-        description  : unindent(matches[10] || '')
+        description  : unindent(matches[11] || ''),
+        sampleValue  : matches[10] || '',
     };
 }
 


### PR DESCRIPTION
Let's provide sample values for `params`. These values later could be used in a sample request form. 