### PR TITLE
fix "Empty parser result" for apiPrivate tag

### DIFF
--- a/lib/parsers/api_private.js
+++ b/lib/parsers/api_private.js
@@ -1,9 +1,5 @@
-var trim = require('../utils/trim');
-
 function parse(content) {
-    content = trim(content);
-
-    return content;
+    return 'private';
 }
 
 /**


### PR DESCRIPTION
Every parser should return a truthly value in order to escape this check 
https://github.com/apidoc/apidoc-core/blob/8c2798cbc528f1c66e8efdc6b7f0051929d1d8bd/lib/parser.js#L291-L293