### PR TITLE
enable the use of an apiUse block in an apiDefine block

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+registry=https://registry.npmjs.org

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -222,7 +222,8 @@ Parser.prototype._parseBlockElements = function(indexApiBlocks, detectedElements
                     preventGlobal = elementParser.preventGlobal === true;
 
                     // allow multiple inserts into pathTo
-                    allowMultiple = elementParser.allowMultiple === true;
+                    //allowMultiple = elementParser.allowMultiple === true;
+                    allowMultiple = true;
 
 
                     // path to an array, where the values should be attached

--- a/lib/workers/api_use.js
+++ b/lib/workers/api_use.js
@@ -66,70 +66,83 @@ function postProcess(parsedFiles, filenames, preProcess, packageInfos, source, t
 
     parsedFiles.forEach(function(parsedFile, parsedFileIndex) {
         parsedFile.forEach(function(block) {
-            if ( ! block.local[target])
-                return;
-
-            block.local[target].forEach(function(definition) {
-                var name = definition.name;
-                var version = block.version || packageInfos.defaultVersion;
-
-                if ( ! preProcess[source] || ! preProcess[source][name]) {
-                    throw new WorkerError('Referenced groupname does not exist / it is not defined with @apiDefine.',
-                        filenames[parsedFileIndex],
-                        block.index,
-                        messages.common.element,
-                        messages.common.usage,
-                        messages.common.example,
-                        [
-                            { 'Groupname': name }
-                        ]
+            var loopCounter = 0;     //add a loop counter to have a break condition when the recursion depth exceed a predifined limit
+	    while (block.local[target]) {
+	        if (loopCounter > 10) {
+	            throw new WorkerError('recursion depth exceeds limit with @apiUse',
+		        filenames[parsedFileIndex],
+		        block.index,
+		        messages.common.element,
+		        messages.common.usage,
+		        messages.common.example,
+		        [
+			   { 'Groupname': name }
+		        ]
                     );
-                }
+	        }
 
-                var matchedData = {};
-                if (preProcess[source][name][version]) {
-                    // found the version
-                    matchedData = preProcess[source][name][version];
-                } else {
-                    // find nearest matching version
-                    var foundIndex = -1;
-                    var lastVersion = packageInfos.defaultVersion;
+                block.local[target].forEach(function(definition) {
+                    var name = definition.name;
+                    var version = block.version || packageInfos.defaultVersion;
 
-                    var versionKeys = Object.keys(preProcess[source][name]);
-                    versionKeys.forEach(function(currentVersion, versionIndex) {
-                        if (semver.gte(version, currentVersion) && semver.gte(currentVersion, lastVersion)) {
-                            lastVersion = currentVersion;
-                            foundIndex = versionIndex;
-                        }
-                    });
-
-                    if (foundIndex === -1) {
-                        throw new WorkerError('Referenced definition has no matching or a higher version. ' +
-                            'Check version number in referenced define block.',
+                    if ( ! preProcess[source] || ! preProcess[source][name]) {
+                        throw new WorkerError('Referenced groupname does not exist / it is not defined with @apiDefine.',
                             filenames[parsedFileIndex],
                             block.index,
                             messages.common.element,
                             messages.common.usage,
                             messages.common.example,
                             [
-                                { 'Groupname': name },
-                                { 'Version': version },
-                                { 'Defined versions': versionKeys },
+                                { 'Groupname': name }
                             ]
                         );
                     }
 
-                    var versionName = versionKeys[foundIndex];
-                    matchedData = preProcess[source][name][versionName];
-                }
+                    var matchedData = {};
+                    if (preProcess[source][name][version]) {
+                        // found the version
+                        matchedData = preProcess[source][name][version];
+                    } else {
+                        // find nearest matching version
+                        var foundIndex = -1;
+                        var lastVersion = packageInfos.defaultVersion;
 
-                // remove target, not needed anymore
-                // TODO: create a cleanup filter
-                delete block.local[target];
+                        var versionKeys = Object.keys(preProcess[source][name]);
+                        versionKeys.forEach(function(currentVersion, versionIndex) {
+                            if (semver.gte(version, currentVersion) && semver.gte(currentVersion, lastVersion)) {
+                                lastVersion = currentVersion;
+                                foundIndex = versionIndex;
+                            }
+                        });
 
-                // copy matched elements into parsed block
-                _recursiveMerge(block.local, matchedData);
-            });
+                        if (foundIndex === -1) {
+                            throw new WorkerError('Referenced definition has no matching or a higher version. ' +
+                                'Check version number in referenced define block.',
+                                filenames[parsedFileIndex],
+                                block.index,
+                                messages.common.element,
+                                messages.common.usage,
+                                messages.common.example,
+                                [
+                                    { 'Groupname': name },
+                                    { 'Version': version },
+                                    { 'Defined versions': versionKeys },
+                                ]
+                            );
+                        }
+
+                        var versionName = versionKeys[foundIndex];
+                        matchedData = preProcess[source][name][versionName];
+                    }
+
+                    // remove target, not needed anymore
+                    // TODO: create a cleanup filter
+                    delete block.local[target];
+
+                    // copy matched elements into parsed block
+                    _recursiveMerge(block.local, matchedData);
+                });
+            }
         });
     });
 }

--- a/lib/workers/api_use.js
+++ b/lib/workers/api_use.js
@@ -80,8 +80,15 @@ function postProcess(parsedFiles, filenames, preProcess, packageInfos, source, t
 		        ]
                     );
 	        }
+                
+                //create a copy of the elements for save iterating of the elements
+                const blockClone = [...block.local[target]];
 
-                block.local[target].forEach(function(definition) {
+                // remove unneeded target before starting the loop, to allow a save insertion of new elements
+                // TODO: create a cleanup filter
+                delete block.local[target];
+
+                blockClone.forEach(function(definition) {
                     var name = definition.name;
                     var version = block.version || packageInfos.defaultVersion;
 
@@ -134,10 +141,6 @@ function postProcess(parsedFiles, filenames, preProcess, packageInfos, source, t
                         var versionName = versionKeys[foundIndex];
                         matchedData = preProcess[source][name][versionName];
                     }
-
-                    // remove target, not needed anymore
-                    // TODO: create a cleanup filter
-                    delete block.local[target];
 
                     // copy matched elements into parsed block
                     _recursiveMerge(block.local, matchedData);

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,12 @@
       "integrity": "sha512-LEHHyuhlPY3TmuUYMh2oz89lTShfvgbmzaBcxve9t/9Wuy7Dwf4yoAKcND7KFT1HAQfqZ12qtc+DUrBMeKF9nw==",
       "dev": true
     },
+    "apidoc-example": {
+      "version": "0.2.1",
+      "resolved": "https://npm.immonex.de/apidoc-example/-/apidoc-example-0.2.1.tgz",
+      "integrity": "sha1-ay0RNZnjSwhkOEFfraDtXeiqR8o=",
+      "dev": true
+    },
     "argparse": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "semver": "~6.3.0"
   },
   "devDependencies": {
+    "apidoc-example": "^0.2.1",
     "jshint": "~2.10.2",
     "markdown-it": "^10.0.0",
     "mocha": "~6.2.1",


### PR DESCRIPTION
Enabled the use of an apiUse block in an apiDefine block

see issue https://github.com/apidoc/apidoc/issues/859

The second commit prevent the deleting of the array while iterating and manipulating it